### PR TITLE
Enable reindex via ui

### DIFF
--- a/app/com/gu/floodgate/AppComponents.scala
+++ b/app/com/gu/floodgate/AppComponents.scala
@@ -48,11 +48,10 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val runningJobService = new RunningJobService(runningJobTable)
   val contentSourceService = new ContentSourceService(contentSourceTable)
   val jobHistoryService = new JobHistoryService(jobHistoryTable)
-  val reindexService = new ReindexService(contentSourceService, runningJobService, wsApi)
+  val reindexService = new ReindexService(contentSourceService, runningJobService, jobHistoryService, wsApi)
 
-  val contentSourceController = new ContentSourceApi(contentSourceService, reindexService, jobHistoryService)
+  val contentSourceController = new ContentSourceApi(contentSourceService, reindexService, jobHistoryService, runningJobService)
   val runningJobController = new RunningJobApi(runningJobService)
-
   val jobHistoryController = new JobHistoryApi(jobHistoryService)
 
   val appController = new Application

--- a/app/com/gu/floodgate/Application.scala
+++ b/app/com/gu/floodgate/Application.scala
@@ -26,4 +26,10 @@ class Application extends Controller with AuthActions with StrictLogging {
     Ok("")
   }
 
+  /* Mock endpoint acting as client for the time being in order to implement reindex */
+  def fakeReindexRouteCancel = Action { implicit request =>
+    println(s"Reindex cancelled.")
+    Ok("")
+  }
+
 }

--- a/app/com/gu/floodgate/DynamoDBTable.scala
+++ b/app/com/gu/floodgate/DynamoDBTable.scala
@@ -118,7 +118,7 @@ trait DynamoDBTable[T] extends StrictLogging {
   }
 
   def deleteItem(id: String) = {
-    val request = new DeleteItemRequest().withTableName(tableName).withKey(Map("id" -> new AttributeValue(id)))
+    val request = new DeleteItemRequest().withTableName(tableName).withKey(Map(keyName -> new AttributeValue(id)))
     dynamoDB.deleteItemAsync(request)
   }
 

--- a/app/com/gu/floodgate/ErrorResponse.scala
+++ b/app/com/gu/floodgate/ErrorResponse.scala
@@ -2,6 +2,9 @@ package com.gu.floodgate
 
 import play.json.extra.JsonFormat
 
+/* Type indicating an operation has been successful but does not necessarily need/require a return type */
+case class Happy()
+
 sealed trait CustomError {
   val message: String
 }
@@ -10,6 +13,7 @@ case class InvalidDateTimeParameter(message: String) extends CustomError
 case class ContentSourceNotFound(message: String) extends CustomError
 case class ReindexAlreadyRunning(message: String) extends CustomError
 case class ReindexCannotBeInitiated(message: String) extends CustomError
+case class CancellingReindexFailed(message: String) extends CustomError
 case class RunningJobNotFound(message: String) extends CustomError
 
 @JsonFormat

--- a/app/com/gu/floodgate/jobhistory/JobHistoryService.scala
+++ b/app/com/gu/floodgate/jobhistory/JobHistoryService.scala
@@ -1,11 +1,13 @@
 package com.gu.floodgate.jobhistory
 
 import com.gu.floodgate.DynamoDBTable
+import com.gu.floodgate.contentsource.ContentSource
 
 import scala.concurrent.Future
 
 class JobHistoryService(jobHistoryTable: DynamoDBTable[JobHistory]) {
 
+  def createJobHistory(jobHistory: JobHistory) = jobHistoryTable.saveItem(jobHistory)
   def getJobHistories(): Future[Seq[JobHistory]] = jobHistoryTable.getAll()
   def getJobHistoryForContentSource(contentSourceId: String): Future[List[JobHistory]] = jobHistoryTable.getItems(contentSourceId)
 

--- a/app/com/gu/floodgate/runningjob/RunningJobService.scala
+++ b/app/com/gu/floodgate/runningjob/RunningJobService.scala
@@ -9,6 +9,7 @@ class RunningJobService(runningJobTable: DynamoDBTable[RunningJob]) {
 
   def createRunningJob(runningJob: RunningJob) = runningJobTable.saveItem(runningJob)
   def getRunningJobs(): Future[Seq[RunningJob]] = runningJobTable.getAll()
+  def getRunningJobsForContentSource(contentSourceId: String): Future[List[RunningJob]] = runningJobTable.getItems(contentSourceId)
 
   def getRunningJob(contentSourceId: String): Future[RunningJob Or CustomError] = {
     runningJobTable.getItem(contentSourceId, keyName = "contentSourceId") map { maybeRunningJob =>
@@ -18,5 +19,7 @@ class RunningJobService(runningJobTable: DynamoDBTable[RunningJob]) {
       )
     }
   }
+
+  def removeRunningJob(id: String) = runningJobTable.deleteItem(id)
 
 }

--- a/conf/routes
+++ b/conf/routes
@@ -20,7 +20,9 @@ POST        /content-source                         com.gu.floodgate.contentsour
 PUT         /content-source/:id                     com.gu.floodgate.contentsource.ContentSourceApi.updateContentSource(id)
 DELETE      /content-source/:id                     com.gu.floodgate.contentsource.ContentSourceApi.deleteContentSource(id)
 POST        /content-source/:id/reindex             com.gu.floodgate.contentsource.ContentSourceApi.reindex(id, from: Option[String], to: Option[String])
+DELETE      /content-source/:id/reindex             com.gu.floodgate.contentsource.ContentSourceApi.cancelReindex(id)
 GET         /content-source/:id/reindex/history     com.gu.floodgate.contentsource.ContentSourceApi.getReindexHistory(id)
+GET         /content-source/:id/reindex/running     com.gu.floodgate.contentsource.ContentSourceApi.getRunningReindexes(id)
 
 
 GET         /job-history                            com.gu.floodgate.jobhistory.JobHistoryApi.getJobHistories
@@ -31,7 +33,7 @@ GET         /running-job/:id                        com.gu.floodgate.runningjob.
 # Fake client reindex endpoints
 
 POST        /reindex                                com.gu.floodgate.Application.fakeReindexRouteInitiate
-
+DELETE      /reindex                                com.gu.floodgate.Application.fakeReindexRouteCancel
 
 # Map static resources from the /public folder to the /assets URL path
 GET        /assets/*file          controllers.Assets.versioned(path="/public", file: Asset)

--- a/public/components/contentSource.react.js
+++ b/public/components/contentSource.react.js
@@ -15,24 +15,19 @@ export default class ContentSource extends React.Component {
     }
 
     initiateReindex() {
-        ContentSourceService.initiateReindex(this.props.contentSource.id).then(response => {
-            console.log(response);
-        },
-        error => {
-            console.log(error.response);
-        })
+        var id = this.props.contentSource.id;
+        this.props.onInitiateReindex(id);
     }
 
     render () {
         return (
             <div id="content-source">
-                <p>ID: {this.props.contentSource.id}</p>
                 <p>Application name: {this.props.contentSource.appName}</p>
                 <p>Description: {this.props.contentSource.description}</p>
                 <p>Endpoint: {this.props.contentSource.reindexEndpoint}</p>
                 <ButtonToolbar>
                     <Button bsStyle="primary" className="pull-right" onClick={this.enterEditMode}>Edit Details</Button>
-                    <Button bsStyle="primary" className="pull-right" onClick={this.initiateReindex}>Reindex</Button>
+                    <Button bsStyle="primary" className="pull-right" onClick={this.initiateReindex.bind(this)}>Reindex</Button>
                 </ButtonToolbar>
             </div>
         );

--- a/public/components/contentSource.react.js
+++ b/public/components/contentSource.react.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ContentSourceService from '../services/contentSourceService';
 import { Button, ButtonToolbar } from 'react-bootstrap';
 
 export default class ContentSource extends React.Component {
@@ -6,21 +7,32 @@ export default class ContentSource extends React.Component {
     constructor(props) {
         super(props);
         this.enterEditMode = this.enterEditMode.bind(this);
+        this.initiateReindex = this.initiateReindex.bind(this);
     }
 
     enterEditMode() {
         this.props.callbackParent(true);
     }
 
+    initiateReindex() {
+        ContentSourceService.initiateReindex(this.props.contentSource.id).then(response => {
+            console.log(response);
+        },
+        error => {
+            console.log(error.response);
+        })
+    }
+
     render () {
         return (
             <div id="content-source">
+                <p>ID: {this.props.contentSource.id}</p>
                 <p>Application name: {this.props.contentSource.appName}</p>
                 <p>Description: {this.props.contentSource.description}</p>
                 <p>Endpoint: {this.props.contentSource.reindexEndpoint}</p>
                 <ButtonToolbar>
                     <Button bsStyle="primary" className="pull-right" onClick={this.enterEditMode}>Edit Details</Button>
-                    <Button bsStyle="primary" className="pull-right">Reindex</Button>
+                    <Button bsStyle="primary" className="pull-right" onClick={this.initiateReindex}>Reindex</Button>
                 </ButtonToolbar>
             </div>
         );

--- a/public/components/jobHistory.react.js
+++ b/public/components/jobHistory.react.js
@@ -9,6 +9,7 @@ export default class JobHistory extends React.Component {
     }
 
     render () {
+
         var jobHistoryNodes = this.props.data.map(function(jobHistory) {
             return (
                 <tr key={jobHistory.startTime}>

--- a/public/components/reactApp.react.js
+++ b/public/components/reactApp.react.js
@@ -24,7 +24,7 @@ export default class ReactApp extends React.Component {
 
     componentDidMount () {
         this.loadContentSources();
-        setInterval(this.loadContentSources, 2000);
+        setInterval(this.loadContentSources, 30000);
     }
 
     render () {

--- a/public/components/reindex.react.js
+++ b/public/components/reindex.react.js
@@ -29,7 +29,7 @@ export default class ReindexComponent extends React.Component {
     componentWillReceiveProps(nextProps) {
         if (this.props.params.id !== nextProps.params.id) {
             this.loadContentSource(nextProps.routeParams.id);
-            this.loadReindexHistory(contentSourceId);
+            this.loadReindexHistory(nextProps.routeParams.id);
             this.setState({editModeOn: false});
         }
     }

--- a/public/components/reindex.react.js
+++ b/public/components/reindex.react.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ContentSource from './contentSource.react';
 import ContentSourceEdit from './contentSourceEdit.react';
 import JobHistory from './jobHistory.react';
+import RunningReindex from './runningReindex.react.js';
 import ContentSourceService from '../services/contentSourceService';
 import { Label, Row, Col, Panel, ProgressBar } from 'react-bootstrap';
 
@@ -13,23 +14,27 @@ export default class ReindexComponent extends React.Component {
         this.state = {
             contentSource: {},
             reindexHistory: [],
+            runningReindex: {},
             editModeOn: false
         };
 
         this.updateEditModeState = this.updateEditModeState.bind(this);
         this.loadContentSource = this.loadContentSource.bind(this);
+        this.loadRunningReindexes = this.loadRunningReindexes.bind(this);
     }
 
     componentDidMount() {
         var contentSourceId = this.props.params.id;
         this.loadContentSource(contentSourceId);
         this.loadReindexHistory(contentSourceId);
+        this.loadRunningReindexes(contentSourceId);
     }
 
     componentWillReceiveProps(nextProps) {
         if (this.props.params.id !== nextProps.params.id) {
             this.loadContentSource(nextProps.routeParams.id);
             this.loadReindexHistory(nextProps.routeParams.id);
+            this.loadRunningReindexes(nextProps.routeParams.id);
             this.setState({editModeOn: false});
         }
     }
@@ -48,6 +53,44 @@ export default class ReindexComponent extends React.Component {
                 reindexHistory: response.jobHistories
             });
         });
+    }
+
+    loadRunningReindexes(contentSourceId) {
+        ContentSourceService.getRunningReindexes(contentSourceId).then(response => {
+            this.setState({
+                runningReindex: response.runningJobs[0]
+            });
+        });
+    }
+
+    initiateReindex(contentSourceId) {
+        ContentSourceService.initiateReindex(contentSourceId).then(response => {
+            this.loadRunningReindexes(contentSourceId);
+        },
+        error => {
+            console.log(error.response);
+        })
+    }
+
+    cancelReindex(currentRunningReindex) {
+        var newReindexHistoryItem = { contentSourceId: currentRunningReindex.contentSourceId, status: 'cancelled', startTime: currentRunningReindex.startTime, finishTime: new Date() };
+
+        ContentSourceService.cancelReindex(currentRunningReindex.contentSourceId).then( response => {
+            // Optimistically add job history and delete running job
+            this.setState({
+                runningReindex: {},
+                reindexHistory: this.state.reindexHistory.concat([newReindexHistoryItem])
+            });
+        },
+        errors => {
+            var indexOfItemToDelete = this.state.reindexHistory.findIndex(r => r.contentSourceId === currentRunningReindex.contentSourceId)
+            //delete job history and add running job
+            this.setState({
+                runningReindex: currentRunningReindex,
+                reindexHistory: this.state.reindexHistory.splice(indexOfItemToDelete, 1)
+            });
+    });
+
     }
 
     updateEditModeState(newState) {
@@ -73,7 +116,19 @@ export default class ReindexComponent extends React.Component {
                                     :
                                     <ContentSource key={this.state.contentSource.id}
                                         contentSource={this.state.contentSource}
-                                        callbackParent={this.updateEditModeState} />
+                                        callbackParent={this.updateEditModeState}
+                                        onInitiateReindex={this.initiateReindex.bind(this)}/>
+                                }
+                            </Panel>
+                        </Col>
+
+                        <Col xs={6} md={6}>
+                            <Panel header="Running Reindexes">
+                                {this.state.runningReindex === undefined || Object.keys(this.state.runningReindex).length === 0 ?
+                                    <p>There are no reindexes currently in progress.</p>
+                                    :
+                                    <RunningReindex data={this.state.runningReindex}
+                                                    onCancelReindex={this.cancelReindex.bind(this)}/>
                                 }
                             </Panel>
                         </Col>

--- a/public/components/runningReindex.react.js
+++ b/public/components/runningReindex.react.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import ContentSourceService from '../services/contentSourceService';
+import { ProgressBar, Button } from 'react-bootstrap';
+
+
+export default class RunningReindex extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.cancelReindex = this.cancelReindex.bind(this);
+    }
+
+    cancelReindex() {
+        var runningReindex = this.props.data
+        this.props.onCancelReindex(runningReindex);
+    }
+
+    render () {
+        return (
+            <div key={this.props.data.startTime}>
+                <ProgressBar striped active now={this.props.data.progress} label="%(percent)s%"/>
+                <Button bsStyle="danger" className="pull-right" type="button" onClick={this.cancelReindex.bind(this)}>Cancel</Button>
+            </div>
+        );
+    }
+}

--- a/public/services/contentSourceService.js
+++ b/public/services/contentSourceService.js
@@ -44,10 +44,25 @@ export default {
         })
     },
 
+    getRunningReindexes:(id) => {
+        return Reqwest({
+            url: '/content-source/' + id + '/reindex/running',
+            contentType: 'text/json',
+            method: 'get'
+        })
+    },
+
     initiateReindex:(id) => {
         return Reqwest({
             url: '/content-source/' + id + '/reindex',
             method: 'post'
+        })
+    },
+
+    cancelReindex:(id) => {
+        return Reqwest({
+            url: '/content-source/' + id + '/reindex',
+            method: 'delete'
         })
     }
 }

--- a/public/services/contentSourceService.js
+++ b/public/services/contentSourceService.js
@@ -5,7 +5,7 @@ export default {
     getContentSources:() => {
         return Reqwest({
             url: '/content-source',
-            contentType: 'application/json',
+            contentType: 'text/json',
             method: 'get'
         })
     },
@@ -13,7 +13,7 @@ export default {
     getContentSource:(id) => {
         return Reqwest({
             url: '/content-source/' + id,
-            contentType: 'application/json',
+            contentType: 'text/json',
             method: 'get'
         })
     },
@@ -41,6 +41,13 @@ export default {
             url: '/content-source/' + id + '/reindex/history',
             contentType: 'text/json',
             method: 'get'
+        })
+    },
+
+    initiateReindex:(id) => {
+        return Reqwest({
+            url: '/content-source/' + id + '/reindex',
+            method: 'post'
         })
     }
 }


### PR DESCRIPTION
This PR adds the following:
 - Ability to initiate a reindex for a content source via the UI.
 - When a reindex is initiated, a progress indicator is displayed on the UI. This does not currently update itself with progress (this is to come).
 - Ability to cancel a reindex. When cancelling a reindex, the progress indicator will disappear and the UI will update the job history with the newly cancelled item.