### PR TITLE
Provide progress updates for running reindexes.

### DIFF
--- a/app/com/gu/floodgate/Application.scala
+++ b/app/com/gu/floodgate/Application.scala
@@ -1,9 +1,10 @@
 package com.gu.floodgate
 
+import com.gu.floodgate.reindex.ReindexStatus.{ Completed, InProgress }
+import com.gu.floodgate.reindex.{ ReindexStatus, Progress }
 import com.typesafe.scalalogging.StrictLogging
 import play.api.libs.json.Json
 import play.api.mvc._
-import play.json.extra.JsonFormat
 
 class Application extends Controller with AuthActions with StrictLogging {
 
@@ -30,6 +31,20 @@ class Application extends Controller with AuthActions with StrictLogging {
   def fakeReindexRouteCancel = Action { implicit request =>
     println(s"Reindex cancelled.")
     Ok("")
+  }
+
+  var progress = 0
+
+  /* Mock endpoint acting as client for the time being in order to implement reindex */
+  def fakeReindexRouteProgress = Action { implicit request =>
+    println(s"Reindex progress.")
+    progress = progress + 10
+    if (progress == 100) {
+      progress = 0
+      Ok(Json.toJson(Progress(Completed, 100, 100)))
+    } else {
+      Ok(Json.toJson(Progress(InProgress, progress, 100)))
+    }
   }
 
 }

--- a/app/com/gu/floodgate/jobhistory/JobHistory.scala
+++ b/app/com/gu/floodgate/jobhistory/JobHistory.scala
@@ -1,11 +1,11 @@
 package com.gu.floodgate.jobhistory
 
+import com.gu.floodgate.reindex.ReindexStatus
 import org.joda.time.DateTime
 import play.json.extra.JsonFormat
 
-// TODO make status enum once we have better idea of statuses to represent.
 @JsonFormat
-case class JobHistory(contentSourceId: String, startTime: DateTime, finishTime: DateTime, status: String)
+case class JobHistory(contentSourceId: String, startTime: DateTime, finishTime: DateTime, status: ReindexStatus)
 
 @JsonFormat
 case class JobHistoriesResponse(jobHistories: Seq[JobHistory])

--- a/app/com/gu/floodgate/reindex/Progress.scala
+++ b/app/com/gu/floodgate/reindex/Progress.scala
@@ -1,0 +1,21 @@
+package com.gu.floodgate.reindex
+
+import play.json.extra.JsonFormat
+import macrame.enum
+import play.json.extra.Picklers._
+
+@enum class ReindexStatus {
+  InProgress("in progress")
+  Failed("failed")
+  Completed("completed")
+  Cancelled("cancelled")
+  Unknown("unknown")
+}
+
+object ReindexStatus extends EnumStringJSON[ReindexStatus] {
+  def asString(s: ReindexStatus): String = asStringImpl(s)
+  def fromString(s: String): Option[ReindexStatus] = fromStringImpl(s)
+}
+
+@JsonFormat
+case class Progress(status: ReindexStatus, documentsIndexed: Int, documentsExpected: Int)

--- a/app/com/gu/floodgate/reindex/ProgressTracker.scala
+++ b/app/com/gu/floodgate/reindex/ProgressTracker.scala
@@ -1,0 +1,128 @@
+package com.gu.floodgate.reindex
+
+import akka.actor.{ Cancellable, Actor, ActorLogging, Props }
+import com.gu.floodgate.contentsource.ContentSource
+import com.gu.floodgate.jobhistory.{ JobHistoryService, JobHistory }
+import com.gu.floodgate.reindex.ProgressTracker.{ Cancel, UpdateProgress, TrackProgress }
+import com.gu.floodgate.runningjob.{ RunningJob, RunningJobService }
+import com.typesafe.scalalogging.StrictLogging
+import org.joda.time.DateTime
+import play.api.libs.ws.{ WSResponse, WSAPI }
+import scala.concurrent.duration._
+import scala.util.{ Failure, Success, Try }
+import com.gu.floodgate.reindex.ReindexStatus.{ Completed, InProgress, Failed, Cancelled }
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object ProgressTracker {
+
+  def props(ws: WSAPI, runningJobService: RunningJobService, jobHistoryService: JobHistoryService) =
+    Props(new ProgressTracker(ws, runningJobService, jobHistoryService))
+
+  case class TrackProgress(contentSource: ContentSource, runningJob: RunningJob)
+  case class UpdateProgress(result: Try[WSResponse], contentSource: ContentSource, runningJob: RunningJob)
+  case class Cancel(contentSource: ContentSource, runningJob: RunningJob)
+
+}
+
+class ProgressTracker(ws: WSAPI, runningJobService: RunningJobService, jobHistoryService: JobHistoryService) extends Actor with ActorLogging with StrictLogging {
+  import context.become
+
+  private val PollInterval = 2.seconds
+  private var nextPollSchedule: Option[Cancellable] = None
+
+  final def receive = sleeping
+
+  private def sleeping: Receive = {
+    case TrackProgress(contentSource, runningJob) =>
+      askForProgress(contentSource, runningJob)
+      become(waitingForProgress)
+
+    case Cancel(contentSource, runningJob) => completeProgressTracking(Cancelled, contentSource, runningJob)
+    case other => logger.warn(s"Unexpected message received while sleeping: $other")
+  }
+
+  private def waitingForProgress: Receive = {
+    case UpdateProgress(result, contentSource, runningJob) =>
+      updateProgress(result, contentSource, runningJob)
+      become(sleeping) // no matter whether the result is good or bad, we should go back to sleeping
+
+    case Cancel => become(waitingForFinalProgress) // don't stop ourselves until we have received the final response (just to avoid a dead letter)
+    case other => logger.warn(s"Unexpected message received while waiting for response: $other")
+  }
+
+  private def waitingForFinalProgress: Receive = {
+    case UpdateProgress(_, contentSource, runningJob) =>
+      completeProgressTracking(Cancelled, contentSource, runningJob) // we've received our last message, so now we can stop (we ignore the response)
+    case Cancel => log.debug("Ignoring a Cancel message because we're already planning to stop after we receive the final response")
+    case other => logger.warn(s"Unexpected message received while waiting for final response: $other")
+  }
+
+  private def askForProgress(contentSource: ContentSource, runningJob: RunningJob): Unit = {
+    val myself = self // make this a val to fix its value, because the onComplete will occur later in a different thread
+    ws.url(contentSource.reindexEndpoint).get() onComplete { result => myself ! UpdateProgress(result, contentSource, runningJob) }
+  }
+
+  private def updateProgress(result: Try[WSResponse], contentSource: ContentSource, runningJob: RunningJob): Unit = {
+    result match {
+      case Success(response) =>
+        response.status match {
+          case 200 => onSuccess(response, contentSource, runningJob)
+          case _ => onFailure(contentSource, runningJob)
+        }
+      case Failure(e) => onFailure(contentSource, runningJob)
+    }
+  }
+
+  private def onSuccess(response: WSResponse, contentSource: ContentSource, runningJob: RunningJob): Unit = {
+    response.json.validate[Progress].fold(
+      error => {
+        logger.warn(s"Content source with id: ${contentSource.id} appears to be returning progress updates in an incorrect format. Marking reindex as cancelled and stop monitoring reindex.")
+        completeProgressTracking(Cancelled, contentSource, runningJob)
+      },
+      progress => actOnProgress(progress, contentSource, runningJob)
+    )
+  }
+
+  private def onFailure(contentSource: ContentSource, runningJob: RunningJob): Unit = {
+    scheduleNextUpdate(contentSource, runningJob)
+  }
+
+  private def actOnProgress(progress: Progress, contentSource: ContentSource, runningJob: RunningJob) = {
+    progress.status match {
+      case Completed =>
+        val runningJobUpdate = RunningJob(runningJob.contentSourceId, progress.documentsIndexed, progress.documentsExpected, runningJob.startTime)
+        completeProgressTracking(Completed, contentSource, runningJobUpdate)
+
+      case Failed => completeProgressTracking(Failed, contentSource, runningJob)
+
+      case InProgress =>
+        val runningJobUpdate = RunningJob(runningJob.contentSourceId, progress.documentsIndexed, progress.documentsExpected, runningJob.startTime)
+        runningJobService.updateRunningJob(runningJob.contentSourceId, runningJobUpdate)
+        scheduleNextUpdate(contentSource, runningJob)
+
+      case _ => logger.warn(s"Incorrect status sent from client: ${progress.status.toString} for content source: ${contentSource.id}")
+    }
+  }
+
+  private def completeProgressTracking(status: ReindexStatus, contentSource: ContentSource, runningJob: RunningJob) = {
+
+    def cleanupAndStop(): Unit = {
+      nextPollSchedule foreach { _.cancel() } // cancel any schedule that we might have set up
+      context.stop(self)
+    }
+
+    val jobHistory = JobHistory(runningJob.contentSourceId, runningJob.startTime, new DateTime(), status)
+    runningJobService.removeRunningJob(runningJob.contentSourceId)
+    jobHistoryService.createJobHistory(jobHistory)
+
+    cleanupAndStop()
+  }
+
+  private def scheduleNextUpdate(contentSource: ContentSource, runningJob: RunningJob): Unit = {
+    val schedule = context.system.scheduler.scheduleOnce(PollInterval, self, TrackProgress(contentSource, runningJob))
+    nextPollSchedule = Some(schedule)
+  }
+
+}
+

--- a/app/com/gu/floodgate/reindex/ProgressTrackerController.scala
+++ b/app/com/gu/floodgate/reindex/ProgressTrackerController.scala
@@ -1,0 +1,43 @@
+package com.gu.floodgate.reindex
+
+import akka.actor.{ ActorRef, ActorLogging, Actor, Props }
+import com.gu.floodgate.contentsource.ContentSource
+import com.gu.floodgate.jobhistory.JobHistoryService
+import com.gu.floodgate.reindex.ProgressTracker.{ Cancel, TrackProgress }
+import com.gu.floodgate.reindex.ProgressTrackerController.{ RemoveTracker, LaunchTracker }
+import com.gu.floodgate.runningjob.{ RunningJob, RunningJobService }
+import com.typesafe.scalalogging.StrictLogging
+import play.api.libs.ws.WSAPI
+
+object ProgressTrackerController {
+  def props(ws: WSAPI, runningJobService: RunningJobService, jobHistoryService: JobHistoryService) = Props(new ProgressTrackerController(ws: WSAPI, runningJobService: RunningJobService, jobHistoryService))
+
+  case class LaunchTracker(contentSource: ContentSource, runningJob: RunningJob)
+  case class RemoveTracker(contentSource: ContentSource, runningJob: RunningJob)
+}
+
+class ProgressTrackerController(ws: WSAPI, runningJobService: RunningJobService, jobHistoryService: JobHistoryService) extends Actor with ActorLogging with StrictLogging {
+
+  private var runningTrackers: Map[String, ActorRef] = Map.empty[String, ActorRef]
+
+  def receive = {
+    case LaunchTracker(contentSource, runningJob) => add(contentSource, runningJob)
+    case RemoveTracker(contentSource, runningJob) => remove(contentSource, runningJob)
+  }
+
+  private def remove(contentSource: ContentSource, runningJob: RunningJob): Unit = {
+    runningTrackers.get(contentSource.id).foreach {
+      case tracker =>
+        tracker ! Cancel(contentSource, runningJob)
+        runningTrackers = runningTrackers - contentSource.id
+    }
+  }
+
+  private def add(contentSource: ContentSource, runningJob: RunningJob): Unit = {
+    val tracker = context.system.actorOf(ProgressTracker.props(ws, runningJobService, jobHistoryService), s"progress-tracker-${contentSource.id}-${runningJob.startTime}")
+    tracker ! TrackProgress(contentSource, runningJob)
+    runningTrackers = runningTrackers + (runningJob.contentSourceId -> tracker)
+  }
+
+}
+

--- a/app/com/gu/floodgate/runningjob/RunningJob.scala
+++ b/app/com/gu/floodgate/runningjob/RunningJob.scala
@@ -4,10 +4,10 @@ import org.joda.time.DateTime
 import play.json.extra.JsonFormat
 
 @JsonFormat
-case class RunningJob(contentSourceId: String, progress: Int, startTime: DateTime)
+case class RunningJob(contentSourceId: String, documentsIndexed: Int, documentsExpected: Int, startTime: DateTime)
 
 object RunningJob {
-  def apply(contentSourceId: String): RunningJob = RunningJob(contentSourceId, 0, new DateTime())
+  def apply(contentSourceId: String): RunningJob = RunningJob(contentSourceId, 0, 0, new DateTime())
 }
 
 @JsonFormat

--- a/app/com/gu/floodgate/runningjob/RunningJobService.scala
+++ b/app/com/gu/floodgate/runningjob/RunningJobService.scala
@@ -8,6 +8,7 @@ import scala.concurrent.Future
 class RunningJobService(runningJobTable: DynamoDBTable[RunningJob]) {
 
   def createRunningJob(runningJob: RunningJob) = runningJobTable.saveItem(runningJob)
+  def updateRunningJob(id: String, runningJob: RunningJob) = runningJobTable.updateItem(id, runningJob)
   def getRunningJobs(): Future[Seq[RunningJob]] = runningJobTable.getAll()
   def getRunningJobsForContentSource(contentSourceId: String): Future[List[RunningJob]] = runningJobTable.getItems(contentSourceId)
 

--- a/app/com/gu/floodgate/runningjob/RunningJobTable.scala
+++ b/app/com/gu/floodgate/runningjob/RunningJobTable.scala
@@ -10,7 +10,8 @@ class RunningJobTable(protected val dynamoDB: AmazonDynamoDBAsyncClient, protect
 
   object fields {
     val ContentSourceId = "contentSourceId"
-    val Progress = "progress"
+    val DocumentsIndexed = "documentsIndexed"
+    val DocumentsExpected = "documentsExpected"
     val StartTime = "startTime"
   }
 
@@ -19,17 +20,19 @@ class RunningJobTable(protected val dynamoDB: AmazonDynamoDBAsyncClient, protect
   override protected def fromItem(item: Map[String, AttributeValue]): RunningJob =
     RunningJob(
       getItemAttributeValue(fields.ContentSourceId, item).getS,
-      getItemAttributeValue(fields.Progress, item).getN.asInstanceOf[Int], // why does toInt not work?
-      new DateTime(getItemAttributeValue(fields.StartTime, item).getS)
-    )
+      BigDecimal(getItemAttributeValue(fields.DocumentsIndexed, item).getN).toInt,
+      BigDecimal(getItemAttributeValue(fields.DocumentsExpected, item).getN).toInt,
+      new DateTime(getItemAttributeValue(fields.StartTime, item).getS))
 
   override protected def toItem(runningJob: RunningJob): Map[String, AttributeValue] =
-    Map(fields.ContentSourceId -> new AttributeValue(runningJob.contentSourceId.toString),
-      fields.Progress -> new AttributeValue(runningJob.progress.toString),
+    Map(fields.ContentSourceId -> new AttributeValue(runningJob.contentSourceId),
+      fields.DocumentsIndexed -> new AttributeValue().withN(runningJob.documentsIndexed.toString),
+      fields.DocumentsExpected -> new AttributeValue().withN(runningJob.documentsExpected.toString),
       fields.StartTime -> new AttributeValue(runningJob.startTime.toString))
 
   override protected def toItemUpdate(runningJob: RunningJob): Map[String, AttributeValueUpdate] =
-    Map(fields.Progress -> new AttributeValueUpdate().withValue(new AttributeValue(runningJob.progress.toString)),
+    Map(fields.DocumentsIndexed -> new AttributeValueUpdate().withValue(new AttributeValue().withN(runningJob.documentsIndexed.toString)),
+      fields.DocumentsExpected -> new AttributeValueUpdate().withValue(new AttributeValue().withN(runningJob.documentsExpected.toString)),
       fields.StartTime -> new AttributeValueUpdate().withValue(new AttributeValue(runningJob.startTime.toString)))
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -7,6 +7,10 @@ google.oauthcallback="http://localhost:9000/oauth2callback"
 google.clientid="828748185794-veekconvnqotvc3toneaj70kglb6jl9i.apps.googleusercontent.com"
 google.clientsecret="2i0IsvSl866E0bHOCEYr8rOi"
 
+akka.actor.default-dispatcher.fork-join-executor.parallelism-max = 64
+akka.actor.debug.receive = on
+
+
 # Web services
 # ~~~~~~
 play.ws.compressionEnabled=true

--- a/conf/routes
+++ b/conf/routes
@@ -32,6 +32,7 @@ GET         /running-job/:id                        com.gu.floodgate.runningjob.
 
 # Fake client reindex endpoints
 
+GET         /reindex                                com.gu.floodgate.Application.fakeReindexRouteProgress
 POST        /reindex                                com.gu.floodgate.Application.fakeReindexRouteInitiate
 DELETE      /reindex                                com.gu.floodgate.Application.fakeReindexRouteCancel
 

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "babel-plugin-transform-object-assign": "^6.0.14",
     "babel-preset-es2015": "^6.0.15",
     "babel-preset-react": "^6.0.15",
+    "history": "1.17.0",
     "node-sass": "^3.3.3",
-    "reqwest": "^2.0.5",
-    "react": "^0.14.6",
+    "react": "^0.14.7",
     "react-bootstrap": "^0.28.2",
     "react-dom": "^0.14.6",
+    "react-interval": "^1.2.1",
     "react-router": "^1.0.0",
-    "history": "1.17.0",
+    "reqwest": "^2.0.5",
     "webpack": "^1.12.11"
   },
   "scripts": {

--- a/public/components/reindex.react.js
+++ b/public/components/reindex.react.js
@@ -57,6 +57,9 @@ export default class ReindexComponent extends React.Component {
 
     loadRunningReindexes(contentSourceId) {
         ContentSourceService.getRunningReindexes(contentSourceId).then(response => {
+
+            if (response.runningJobs.length === 0) this.loadReindexHistory(contentSourceId);
+
             this.setState({
                 runningReindex: response.runningJobs[0]
             });
@@ -128,7 +131,8 @@ export default class ReindexComponent extends React.Component {
                                     <p>There are no reindexes currently in progress.</p>
                                     :
                                     <RunningReindex data={this.state.runningReindex}
-                                                    onCancelReindex={this.cancelReindex.bind(this)}/>
+                                                    onCancelReindex={this.cancelReindex.bind(this)}
+                                                    onReloadRunningReindexes={this.loadRunningReindexes.bind(this)}/>
                                 }
                             </Panel>
                         </Col>

--- a/public/components/runningReindex.react.js
+++ b/public/components/runningReindex.react.js
@@ -1,24 +1,64 @@
 import React from 'react';
 import ContentSourceService from '../services/contentSourceService';
 import { ProgressBar, Button } from 'react-bootstrap';
+import ReactInterval from 'react-interval';
 
 
 export default class RunningReindex extends React.Component {
 
     constructor(props) {
         super(props);
+
+        this.state = {
+            timeout: 2000,
+            progressUpdatesEnabled: false,
+            progress: 0
+        };
+
         this.cancelReindex = this.cancelReindex.bind(this);
     }
 
+    componentDidMount() {
+        this.setState({
+            progress: this.computeProgress( this.props.data.documentsIndexed, this.props.data.documentsExpected),
+            progressUpdatesEnabled: true
+        });
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({
+            progress: this.computeProgress( nextProps.data.documentsIndexed, nextProps.data.documentsExpected),
+            progressUpdatesEnabled: true
+        });
+    }
+
+    updateRunningReindexes() {
+        var contentSourceId = this.props.data.contentSourceId;
+        this.props.onReloadRunningReindexes(contentSourceId);
+    }
+
+    computeProgress(documentsIndexed, documentsExpected) {
+        var progress = 0;
+
+        if (documentsExpected != 0) {
+            progress = documentsIndexed / documentsExpected * 100;
+        }
+        return progress;
+    }
+
     cancelReindex() {
-        var runningReindex = this.props.data
+        var runningReindex = this.props.data;
         this.props.onCancelReindex(runningReindex);
     }
 
+
     render () {
+
         return (
             <div key={this.props.data.startTime}>
-                <ProgressBar striped active now={this.props.data.progress} label="%(percent)s%"/>
+                <ReactInterval timeout={this.state.timeout} enabled={this.state.progressUpdatesEnabled}
+                               callback={ this.updateRunningReindexes.bind(this) } />
+                <ProgressBar striped active now={this.state.progress} label="%(percent)s%"/>
                 <Button bsStyle="danger" className="pull-right" type="button" onClick={this.cancelReindex.bind(this)}>Cancel</Button>
             </div>
         );


### PR DESCRIPTION
This change implements reindex progress updates against a fake endpoint inside that
application for now that fakes the response that we would expect to receive from a potential
client.

[Polling actor modelled on @cb372's really nice implementation in Pubflow]