### PR TITLE
Provide settings per content source to allow for differences between them.

### DIFF
--- a/app/com/gu/floodgate/contentsource/ContentSource.scala
+++ b/app/com/gu/floodgate/contentsource/ContentSource.scala
@@ -1,6 +1,7 @@
 package com.gu.floodgate.contentsource
 
 import java.util.UUID
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.gu.floodgate.reindex.DateParameters
 import play.json.extra.JsonFormat
 
@@ -13,7 +14,8 @@ case class ContentSourceWithoutId(
   description: String,
   reindexEndpoint: String,
   environment: String,
-  authType: String)
+  authType: String,
+  contentSourceSettings: ContentSourceSettings)
 
 @JsonFormat
 case class ContentSourcesResponse(contentSources: Seq[ContentSource])
@@ -22,13 +24,38 @@ case class ContentSourcesResponse(contentSources: Seq[ContentSource])
 case class SingleContentSourceResponse(contentSource: ContentSource)
 
 @JsonFormat
+case class ContentSourceSettings(supportsToFromParams: Boolean = true, supportsCancelReindex: Boolean = true) {
+
+  def toMap = {
+    Map(ContentSourceSettings.fields.SupportsToFromParams -> this.supportsToFromParams,
+      ContentSourceSettings.fields.SupportsCancelReindex -> this.supportsCancelReindex)
+  }
+}
+
+object ContentSourceSettings {
+
+  object fields {
+    val SupportsToFromParams = "supportsToFromParams"
+    val SupportsCancelReindex = "supportsCancelReindex"
+  }
+
+  def apply(settings: Map[String, AttributeValue]): ContentSourceSettings = {
+    val supportsToFromParams = settings.getOrElse(ContentSourceSettings.fields.SupportsToFromParams, new AttributeValue("true")).getBOOL
+    val supportsCancelReindex = settings.getOrElse(ContentSourceSettings.fields.SupportsCancelReindex, new AttributeValue("true")).getBOOL
+
+    ContentSourceSettings(supportsToFromParams, supportsCancelReindex)
+  }
+}
+
+@JsonFormat
 case class ContentSource(
     id: String,
     appName: String,
     description: String,
     reindexEndpoint: String,
     environment: String,
-    authType: String) {
+    authType: String,
+    contentSourceSettings: ContentSourceSettings) {
 
   def uniqueId: String = s"$id-$environment"
 
@@ -47,7 +74,7 @@ case class ContentSource(
 }
 
 /*
- * Used for updates as we do not allow the user to update their id or environment which act as hashkey and sort key in
+ * Used for updates as we do not allow the user to update their id or environment, which act as hashkey and sort key in
  * the DB.
  */
 @JsonFormat
@@ -55,18 +82,19 @@ case class ContentWithoutIdAndEnvironment(
   appName: String,
   description: String,
   reindexEndpoint: String,
-  authType: String)
+  authType: String,
+  contentSourceSettings: ContentSourceSettings)
 
 object ContentSource {
 
   def apply(contentSourceWithoutId: ContentSourceWithoutId): ContentSource = {
     val id = UUID.randomUUID().toString
     ContentSource(id, contentSourceWithoutId.appName, contentSourceWithoutId.description,
-      contentSourceWithoutId.reindexEndpoint, contentSourceWithoutId.environment, contentSourceWithoutId.authType)
+      contentSourceWithoutId.reindexEndpoint, contentSourceWithoutId.environment, contentSourceWithoutId.authType, contentSourceWithoutId.contentSourceSettings)
   }
 
   def apply(id: String, environment: String, contentSource: ContentWithoutIdAndEnvironment): ContentSource = {
     val id = UUID.randomUUID().toString
-    ContentSource(id, contentSource.appName, contentSource.description, contentSource.reindexEndpoint, environment, contentSource.authType)
+    ContentSource(id, contentSource.appName, contentSource.description, contentSource.reindexEndpoint, environment, contentSource.authType, contentSource.contentSourceSettings)
   }
 }

--- a/app/com/gu/floodgate/contentsource/ContentSourceTable.scala
+++ b/app/com/gu/floodgate/contentsource/ContentSourceTable.scala
@@ -1,8 +1,9 @@
 package com.gu.floodgate.contentsource
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
-import com.amazonaws.services.dynamodbv2.model.{ AttributeAction, AttributeValue, AttributeValueUpdate }
+import com.amazonaws.services.dynamodbv2.model.{ AttributeValue, AttributeValueUpdate }
 import com.gu.floodgate.DynamoDBTable
+import scala.collection.JavaConverters._
 
 class ContentSourceTable(protected val dynamoDB: AmazonDynamoDBAsyncClient, protected val tableName: String)
     extends DynamoDBTable[ContentSource] {
@@ -14,32 +15,45 @@ class ContentSourceTable(protected val dynamoDB: AmazonDynamoDBAsyncClient, prot
     val AppName = "appName"
     val Description = "description"
     val ReindexEndpoint = "reindexEndpoint"
+    val ContentSourceSettings = "contentSourceSettings"
   }
 
   override protected val keyName: String = fields.Id
   override protected val maybeSortKeyName: Option[String] = Some(fields.Environment)
 
-  override protected def fromItem(item: Map[String, AttributeValue]): ContentSource =
+  override protected def fromItem(item: Map[String, AttributeValue]): ContentSource = {
+    val contentSourceSettings = getItemAttributeValue(fields.ContentSourceSettings, item).getM.asScala.toMap
+
     ContentSource(
       getItemAttributeValue(fields.Id, item).getS,
       getItemAttributeValue(fields.AppName, item).getS,
       getItemAttributeValue(fields.Description, item).getS,
       getItemAttributeValue(fields.ReindexEndpoint, item).getS,
       getItemAttributeValue(fields.Environment, item).getS,
-      getItemAttributeValue(fields.AuthType, item).getS)
+      getItemAttributeValue(fields.AuthType, item).getS,
+      ContentSourceSettings(contentSourceSettings)
+    )
+  }
 
-  override protected def toItem(contentSource: ContentSource): Map[String, AttributeValue] =
+  override protected def toItem(contentSource: ContentSource): Map[String, AttributeValue] = {
+    val contentSourceSettings = contentSource.contentSourceSettings.toMap.mapValues(new AttributeValue().withBOOL(_)).asJava
+
     Map(fields.Id -> new AttributeValue(contentSource.id),
       fields.AppName -> new AttributeValue(contentSource.appName),
       fields.Description -> new AttributeValue(contentSource.description),
       fields.ReindexEndpoint -> new AttributeValue(contentSource.reindexEndpoint),
       fields.Environment -> new AttributeValue(contentSource.environment),
-      fields.AuthType -> new AttributeValue(contentSource.authType))
+      fields.AuthType -> new AttributeValue(contentSource.authType),
+      fields.ContentSourceSettings -> new AttributeValue().withM(contentSourceSettings))
+  }
 
-  override protected def toItemUpdate(contentSource: ContentSource): Map[String, AttributeValueUpdate] =
+  override protected def toItemUpdate(contentSource: ContentSource): Map[String, AttributeValueUpdate] = {
+    val contentSourceSettings = contentSource.contentSourceSettings.toMap.mapValues(new AttributeValue().withBOOL(_)).asJava
+
     Map(fields.AppName -> new AttributeValueUpdate().withValue(new AttributeValue(contentSource.appName)),
       fields.Description -> new AttributeValueUpdate().withValue(new AttributeValue(contentSource.description)),
       fields.ReindexEndpoint -> new AttributeValueUpdate().withValue(new AttributeValue(contentSource.reindexEndpoint)),
-      fields.AuthType -> new AttributeValueUpdate().withValue(new AttributeValue(contentSource.authType)))
-
+      fields.AuthType -> new AttributeValueUpdate().withValue(new AttributeValue(contentSource.authType)),
+      fields.ContentSourceSettings -> new AttributeValueUpdate().withValue(new AttributeValue().withM(contentSourceSettings)))
+  }
 }

--- a/public/components/contentSource.react.js
+++ b/public/components/contentSource.react.js
@@ -15,13 +15,13 @@ export default class ContentSource extends React.Component {
 
     render () {
         return (
+
             <div id="content-source">
                 <p><strong>Application name:</strong> {this.props.contentSource.appName}</p>
                 <p><strong>Description:</strong> {this.props.contentSource.description}</p>
                 <p><strong>Environment:</strong> {this.props.contentSource.environment}</p>
                 <p><strong>Endpoint:</strong> {this.props.contentSource.reindexEndpoint}</p>
                 <p><strong>Auth type:</strong> {this.props.contentSource.authType}</p>
-
 
                 <ButtonToolbar>
                     <Button bsStyle="primary" className="pull-right" onClick={this.enterEditMode}> Edit Details</Button>

--- a/public/components/contentSourceCreate.react.js
+++ b/public/components/contentSourceCreate.react.js
@@ -13,6 +13,8 @@ export default class ContentSourceForm extends React.Component {
             reindexEndpoint: '',
             environment: '',
             authType: '',
+            supportsToFromParams: true,
+            supportsCancelReindex: true,
             alertStyle: 'success',
             alertMessage: '',
             alertVisibility: false
@@ -28,7 +30,7 @@ export default class ContentSourceForm extends React.Component {
     }
 
     resetFormFields() {
-        this.setState({appName: '', description: '', reindexEndpoint: '', environment: '', authType: ''});
+        this.setState({appName: '', description: '', reindexEndpoint: '', environment: '', authType: '', supportsToFromParams: true, supportsCancelReindex: true});
     }
 
     handleAppNameChange(e) {
@@ -51,6 +53,14 @@ export default class ContentSourceForm extends React.Component {
         this.setState({authType: e.target.value});
     }
 
+    handleSupportsToFromParams(e) {
+        this.setState({supportsToFromParams: e.target.checked});
+    }
+
+    handleSupportsCancelReindex(e) {
+        this.setState({supportsCancelReindex: e.target.checked});
+    }
+
     handleSubmit(e) {
         e.preventDefault();
         var appName = this.state.appName.trim();
@@ -58,6 +68,8 @@ export default class ContentSourceForm extends React.Component {
         var reindexEndpoint = this.state.reindexEndpoint.trim();
         var environment = this.state.environment.trim();
         var authType = this.state.authType.trim();
+        var supportsToFromParams = this.state.supportsToFromParams;
+        var supportsCancelReindex = this.state.supportsCancelReindex;
 
         if(appName && description && reindexEndpoint && environment && authType ) {
             this.handleFormSubmit({
@@ -65,7 +77,11 @@ export default class ContentSourceForm extends React.Component {
                 description: description,
                 reindexEndpoint: reindexEndpoint,
                 environment: environment,
-                authType: authType
+                authType: authType,
+                contentSourceSettings: {
+                    supportsToFromParams: supportsToFromParams,
+                    supportsCancelReindex: supportsCancelReindex
+                }
             });
         } else {
             this.setState({alertStyle: 'danger', alertMessage: 'Invalid form. Correct the fields and try again.', alertVisibility: true});
@@ -103,6 +119,15 @@ export default class ContentSourceForm extends React.Component {
                                 <option value="api-key">Api key</option>
                                 <option value="vpc-peered">VPC peered</option>
                             </Input>
+                        </Col>
+                    </Input>
+
+                    <Input label="Settings" labelClassName="col-xs-2" wrapperClassName="wrapper">
+                        <Col xs={4}>
+                            <Input type="checkbox" defaultChecked={this.state.supportsToFromParams} onChange={this.handleSupportsToFromParams.bind(this)} label="Supports to/from reindex parameters" />
+                        </Col>
+                        <Col xs={4}>
+                            <Input type="checkbox" defaultChecked={this.state.supportsCancelReindex} onChange={this.handleSupportsCancelReindex.bind(this)} label="Supports cancelling of a reindex" />
                         </Col>
                     </Input>
 

--- a/public/components/contentSourceEdit.react.js
+++ b/public/components/contentSourceEdit.react.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, ButtonToolbar, Input, Alert } from 'react-bootstrap';
+import { Button, ButtonToolbar, Input, Alert, Col } from 'react-bootstrap';
 import ContentSourceService from '../services/contentSourceService';
 
 export default class ContentSourceEdit extends React.Component {
@@ -11,6 +11,8 @@ export default class ContentSourceEdit extends React.Component {
             description: this.props.contentSource.description,
             reindexEndpoint: this.props.contentSource.reindexEndpoint,
             authType: this.props.contentSource.authType,
+            supportsToFromParams: this.props.contentSource.contentSourceSettings.supportsToFromParams,
+            supportsCancelReindex: this.props.contentSource.contentSourceSettings.supportsCancelReindex,
             alertStyle: 'success',
             alertMessage: '',
             alertVisibility: false
@@ -34,6 +36,15 @@ export default class ContentSourceEdit extends React.Component {
         this.setState({authType: e.target.value});
     }
 
+    handleSupportsToFromParams(e) {
+        this.setState({supportsToFromParams: e.target.checked});
+
+    }
+
+    handleSupportsCancelReindex(e) {
+        this.setState({supportsCancelReindex: e.target.checked});
+    }
+
     exitEditMode() {
         this.props.callbackParent(false);
     }
@@ -44,10 +55,19 @@ export default class ContentSourceEdit extends React.Component {
         var description = this.state.description.trim();
         var reindexEndpoint = this.state.reindexEndpoint.trim();
         var authType = this.state.authType.trim();
+        var supportsToFromParams = this.state.supportsToFromParams;
+        var supportsCancelReindex = this.state.supportsCancelReindex;
 
-        if(appName && description && reindexEndpoint && authType) {
+        if(appName && description && reindexEndpoint && authType && supportsToFromParams != undefined && supportsCancelReindex != undefined) {
             this.handleFormSubmit(this.props.contentSource.id, this.props.contentSource.environment,
-                {appName: appName, description: description, reindexEndpoint: reindexEndpoint, authType: authType});
+                {appName: appName,
+                 description: description,
+                 reindexEndpoint: reindexEndpoint,
+                 authType: authType,
+                 contentSourceSettings: {
+                     supportsToFromParams: supportsToFromParams,
+                     supportsCancelReindex: supportsCancelReindex
+                 }});
         } else {
             this.setState({alertStyle: 'danger', alertMessage: 'Invalid form. Correct the fields and try again.', alertVisibility: true});
             return;
@@ -74,6 +94,15 @@ export default class ContentSourceEdit extends React.Component {
                         <option value="" selected disabled>Select authentication type ... </option>
                         <option value="api-key">Api key</option>
                         <option value="vpc-peered">VPC peered</option>
+                    </Input>
+
+                    <Input label="Settings" labelClassName="col-xs-2" wrapperClassName="wrapper">
+                        <Col xs={4}>
+                            <Input type="checkbox" defaultChecked={this.state.supportsToFromParams} onChange={this.handleSupportsToFromParams.bind(this)} label="Supports to/from reindex parameters" />
+                        </Col>
+                        <Col xs={4}>
+                            <Input type="checkbox" defaultChecked={this.state.supportsCancelReindex} onChange={this.handleSupportsCancelReindex.bind(this)} label="Supports cancelling of a reindex" />
+                        </Col>
                     </Input>
 
                     <ButtonToolbar>

--- a/public/components/reindexController.react.js
+++ b/public/components/reindexController.react.js
@@ -120,30 +120,39 @@ export default class ReindexControllerComponent extends React.Component {
                         </Col>
                         <Col xs={5} md={5}>
                             <Panel header="Details">
-                                {this.state.editModeOn ?
+                                {this.state.editModeOn  ?
                                     <ContentSourceEdit key={this.state.contentSource.id}
                                         contentSource={this.state.contentSource}
                                         callbackParent={this.updateEditModeState} />
                                     :
-                                    <ContentSource key={this.state.contentSource.id}
-                                        contentSource={this.state.contentSource}
-                                        callbackParent={this.updateEditModeState}/>
+                                    this.state.contentSource.contentSourceSettings != undefined ?
+                                        <ContentSource key={this.state.contentSource.id}
+                                            contentSource={this.state.contentSource}
+                                            callbackParent={this.updateEditModeState}/>
+                                        : null
                                 }
                             </Panel>
 
                             <Panel header="Start Reindex">
-                                <ReindexForm key={this.state.contentSource.id}
-                                             contentSource={this.state.contentSource}
-                                             onInitiateReindex={this.initiateReindex.bind(this)}/>
+                                {this.state.contentSource.contentSourceSettings != undefined ?
+                                    <ReindexForm key={this.state.contentSource.id}
+                                        contentSource={this.state.contentSource}
+                                        onInitiateReindex={this.initiateReindex.bind(this)}/>
+                                    : null
+                                }
                             </Panel>
                         </Col>
 
                         <Col xs={7} md={7}>
                             <Panel header="Running Reindexes">
-                                {this.state.runningReindex === undefined || Object.keys(this.state.runningReindex).length === 0 ?
+                                {this.state.runningReindex === undefined ||
+                                 Object.keys(this.state.runningReindex).length === 0 ||
+                                 this.state.contentSource.contentSourceSettings === undefined ||
+                                 Object.keys(this.state.contentSource).length === 0 ?
                                     <p>There are no reindexes currently in progress.</p>
                                     :
                                     <RunningReindex data={this.state.runningReindex}
+                                                    isCancelSupported={this.state.contentSource.contentSourceSettings.supportsCancelReindex}
                                                     onCancelReindex={this.cancelReindex.bind(this)}
                                                     onReloadRunningReindex={this.loadRunningReindex.bind(this)}/>
                                 }

--- a/public/components/reindexForm.react.js
+++ b/public/components/reindexForm.react.js
@@ -6,6 +6,7 @@ export default class ReindexForm extends React.Component {
 
     constructor(props) {
         super(props);
+
         this.state = {
             startDate: Moment().format('YYYY-MM-DD'),
             endDate: Moment().format('YYYY-MM-DD'),
@@ -15,10 +16,11 @@ export default class ReindexForm extends React.Component {
     }
 
     initiateReindex() {
+        var isToFromSupported = this.props.contentSource.contentSourceSettings.supportsToFromParams;
         var id = this.props.contentSource.id;
         var environment = this.props.contentSource.environment;
-        var startDate = this.state.startDate === '' ? '' : Moment(this.state.startDate).toISOString();
-        var endDate = this.state.endDate === '' ? '' : Moment(this.state.endDate).endOf('day').toISOString();
+        var startDate = this.state.startDate === '' || !isToFromSupported ? '' : Moment(this.state.startDate).toISOString();
+        var endDate = this.state.endDate === '' || !isToFromSupported ? '' : Moment(this.state.endDate).endOf('day').toISOString();
 
         if(Moment(endDate).isBefore(startDate))
             this.setState({
@@ -60,14 +62,19 @@ export default class ReindexForm extends React.Component {
             <div>
                 { this.state.alertVisibility ? <Alert bsStyle={this.state.alertStyle} onDismiss={this.handleAlertDismiss.bind(this)}>{this.state.alertMessage}</Alert> : null }
                 <form>
-                    <Row>
-                        <Col xs={6}>
-                            <Input type="date" label="Start date" value={this.state.startDate} onChange={this.handleStartDate.bind(this)} />
-                        </Col>
-                        <Col xs={6}>
-                            <Input type="date" label="End Date" value={this.state.endDate} onChange={this.handleEndDate.bind(this)} />
-                        </Col>
-                    </Row>
+
+                    {this.props.contentSource.contentSourceSettings.supportsToFromParams ?
+                        <Row>
+                            <Col xs={6}>
+                                <Input type="date" label="Start date" value={this.state.startDate} onChange={this.handleStartDate.bind(this)} />
+                            </Col>
+                            <Col xs={6}>
+                                <Input type="date" label="End Date" value={this.state.endDate} onChange={this.handleEndDate.bind(this)} />
+                            </Col>
+                        </Row>
+                        :
+                        <Alert bsStyle="info">Reindexing for a specific period of time is not supported with this content source. You may only reindex <strong>all</strong>.</Alert>
+                    }
                     <Button bsStyle="primary" className="pull-right" onClick={this.initiateReindex.bind(this)}>Reindex</Button>
                 </form>
             </div>

--- a/public/components/runningReindex.react.js
+++ b/public/components/runningReindex.react.js
@@ -60,7 +60,11 @@ export default class RunningReindex extends React.Component {
                 <ReactInterval timeout={this.state.timeout} enabled={this.state.progressUpdatesEnabled}
                                callback={ this.updateRunningReindex.bind(this) } />
                 <ProgressBar striped active now={this.state.progress} label="%(percent)s%"/>
-                <Button bsStyle="danger" className="pull-right" type="button" onClick={this.cancelReindex.bind(this)}>Cancel</Button>
+
+                {this.props.isCancelSupported ?
+                    <Button bsStyle="danger" className="pull-right" type="button" onClick={this.cancelReindex.bind(this)}>Cancel</Button>
+                    : null
+                }
             </div>
         );
     }


### PR DESCRIPTION
The reindex operations of different content sources vary in time, with some being extremely quick (tags & sections) to some taking much longer. Therefore it does not make sense for applications that reindex quickly to implement the ability to cancel a reindex or to allow a reindex for a specific time period necessarily. This pull request provides the flexibility for this and reflects it in the UI.