### PR TITLE
Fix to Play 2.6 Upgrade

### DIFF
--- a/app/com/gu/floodgate/Application.scala
+++ b/app/com/gu/floodgate/Application.scala
@@ -8,10 +8,12 @@ import play.api.mvc.legacy.Controller
 import com.gu.floodgate.views
 import play.api.libs.ws.WSClient
 import com.gu.floodgate.Formats._
+import com.gu.googleauth.{ AuthAction, GoogleAuthConfig }
+import play.api.mvc.AnyContent
 
-class Application(val wsClient: WSClient, val conf: Configuration) extends Controller with AuthActions with StrictLogging {
+class Application(authAction: AuthAction[AnyContent], authConfig: GoogleAuthConfig, val wsClient: WSClient, val conf: Configuration) extends Controller with StrictLogging {
 
-  def index = AuthAction {
+  def index = authAction {
     Ok(views.html.app("Floodgate"))
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,15 +15,13 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
   "com.typesafe.play" %% "play-json" % "2.6.0",
   "com.typesafe.play" %% "play-json-joda" % "2.6.0",
-  "com.gu" %% "play-googleauth" % "0.6.0",
+  "com.gu" %% "play-googleauth" % "0.7.0",
   "com.gu" %% "scanamo" % "0.9.2",
   "org.scalatest" %% "scalatest" % "2.2.5" % "test",
   "com.typesafe.play" %% "play-specs2" % "2.6.0",
   "org.typelevel" %% "cats-core" % "0.9.0",
   "com.typesafe.play" %% "play-logback" % "2.6.0"
 )
-
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
 routesGenerator := InjectedRoutesGenerator
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,7 +1,7 @@
 play.http.secret.key = "changeme"
 play.http.secret.key = ${?CRYPTO_SECRET}
 play.i18n.langs = [ "en" ]
-play.application.loader = AppLoader
+play.application.loader = com.gu.floodgate.AppLoader
 
 google.oauthcallback="http://localhost:9000/oauth2callback"
 google.clientid="828748185794-veekconvnqotvc3toneaj70kglb6jl9i.apps.googleusercontent.com"

--- a/conf/routes
+++ b/conf/routes
@@ -10,7 +10,7 @@ GET        /healthcheck                                                   contro
 
 # Auth
 GET         /login                                                        controllers.Login.login
-GET         /loginAction                                                   controllers.Login.loginAction
+GET         /loginAction                                                  controllers.Login.loginAction
 GET         /oauth2callback                                               controllers.Login.oauth2Callback
 
 # Api


### PR DESCRIPTION
[Previous changes](https://github.com/guardian/floodgate/pull/48) were failing to deploy as 
play-googleauth didn't yet support Play 2.6. These changes reflect the latest version.