### PR TITLE
Add capability to handle batch reindexing jobs

### DIFF
--- a/app/com/gu/floodgate/AppComponents.scala
+++ b/app/com/gu/floodgate/AppComponents.scala
@@ -1,13 +1,14 @@
 package com.gu.floodgate
 
+import akka.actor.ActorRef
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{ AWSCredentialsProviderChain, InstanceProfileCredentialsProvider }
 import com.amazonaws.regions.{ Region, Regions }
 import com.amazonaws.services.dynamodbv2._
-import com.gu.floodgate.contentsource.{ ContentSourceApi, ContentSourceService, ContentSourceTable }
+import com.gu.floodgate.contentsource.{ ContentSource, ContentSourceApi, ContentSourceService, ContentSourceTable }
 import com.gu.floodgate.jobhistory.{ JobHistoryApi, JobHistoryService, JobHistoryTable }
-import com.gu.floodgate.reindex.{ ProgressTrackerController, ReindexService }
+import com.gu.floodgate.reindex.{ BulkJobActor, ProgressTrackerController, ReindexService }
 import com.gu.floodgate.runningjob.{ RunningJobApi, RunningJobService, RunningJobTable }
 import com.gu.googleauth.{ AuthAction, GoogleAuthConfig }
 import play.api.ApplicationLoader.Context
@@ -63,10 +64,22 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   )
 
   val reindexService = new ReindexService(contentSourceService, runningJobService, jobHistoryService, progressTrackerControllerActor, wsClient)
-
-  val contentSourceController = new ContentSourceApi(contentSourceService, reindexService, jobHistoryService, runningJobService)
   val runningJobController = new RunningJobApi(runningJobService)
   val jobHistoryController = new JobHistoryApi(jobHistoryService)
+
+  val previewCodeBulkJobActor = generateBulkActors("draft-code")
+  val liveCodeBulkJobActor = generateBulkActors("live-code")
+  val previewProdBulkJobActor = generateBulkActors("draft-prod")
+  val liveProdBulkJobActor = generateBulkActors("live-prod")
+
+  val bulkActorsMap = Map(
+    "draft-code" -> previewCodeBulkJobActor,
+    "live-code" -> liveCodeBulkJobActor,
+    "draft-prod" -> previewProdBulkJobActor,
+    "live-prod" -> liveProdBulkJobActor
+  )
+
+  val contentSourceController = new ContentSourceApi(contentSourceService, reindexService, jobHistoryService, runningJobService, bulkActorsMap)
 
   val authConfig = {
     val clientId = configuration.get[String]("google.clientid")
@@ -83,5 +96,11 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
 
   val router: Router = new Routes(httpErrorHandler, appController, healthcheckController, loginController,
     contentSourceController, jobHistoryController, runningJobController, assets)
+
+  def generateBulkActors(environment: String): ActorRef = {
+    val contentSources = contentSourceTable.getAllSync[ContentSource]()
+    val idList = contentSources.filter(contentSource => contentSource.environment == environment).toList
+    actorSystem.actorOf(BulkJobActor.props(idList, runningJobService, reindexService, jobHistoryService), s"${environment}-bulk-job")
+  }
 
 }

--- a/app/com/gu/floodgate/DynamoDBTable.scala
+++ b/app/com/gu/floodgate/DynamoDBTable.scala
@@ -8,9 +8,10 @@ import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.query.{ KeyEquals, UniqueKey }
 import com.gu.scanamo.{ DynamoFormat, Scanamo }
 import com.typesafe.scalalogging.StrictLogging
+
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
-import scala.concurrent.{ Promise, Future }
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 
 trait DynamoDBTable[T] extends StrictLogging {
 
@@ -43,6 +44,18 @@ trait DynamoDBTable[T] extends StrictLogging {
     promise.future
   }
 
+  def getAllSync[T: DynamoFormat](): Seq[T] = {
+    Scanamo.scan[T](dynamoDB)(tableName).flatMap { either =>
+      either.fold(
+        error => {
+          logger.error(error.toString)
+          None
+        },
+        result => Some(result)
+      )
+    }
+  }
+
   def getItem[T: DynamoFormat](hashKey: String, sortKey: String): Option[Either[DynamoReadError, T]] = {
     maybeSortKeyName flatMap { sortKeyName =>
       Scanamo.get[T](dynamoDB)(tableName)(UniqueKey(KeyEquals(Symbol(keyName), hashKey) and KeyEquals(Symbol(sortKeyName), sortKey)))
@@ -69,6 +82,20 @@ trait DynamoDBTable[T] extends StrictLogging {
       ))
 
     getListOfItems(request)
+  }
+
+  def getLatestItem(id: String, filterKeyName: String, filterValue: String)(implicit ec: ExecutionContext): Future[Option[T]] = {
+    val request = new QueryRequest().withTableName(tableName)
+      .withScanIndexForward(false)
+      .withKeyConditionExpression(s"$keyName = :$keyName")
+      .withFilterExpression(s"$filterKeyName = :$filterKeyName")
+      .withLimit(1)
+      .withExpressionAttributeValues(Map(
+        s":$keyName" -> new AttributeValue().withS(id),
+        s":$filterKeyName" -> new AttributeValue().withS(filterValue)
+      ))
+
+    getListOfItems(request).map(resultList => resultList.headOption)
   }
 
   def saveItem[T: DynamoFormat](t: T): PutItemResult = {

--- a/app/com/gu/floodgate/ErrorResponse.scala
+++ b/app/com/gu/floodgate/ErrorResponse.scala
@@ -13,6 +13,7 @@ case class InvalidDateTimeParameter(message: String) extends CustomError
 case class ContentSourceNotFound(message: String) extends CustomError
 case class ReindexAlreadyRunning(message: String) extends CustomError
 case class ReindexCannotBeInitiated(message: String) extends CustomError
+case class BulkReindexInProcess(message: String) extends CustomError
 case class CancellingReindexFailed(message: String) extends CustomError
 case class RunningJobNotFound(message: String) extends CustomError
 case class ScanamoReadError(message: String) extends CustomError

--- a/app/com/gu/floodgate/ErrorResponse.scala
+++ b/app/com/gu/floodgate/ErrorResponse.scala
@@ -15,5 +15,6 @@ case class ReindexAlreadyRunning(message: String) extends CustomError
 case class ReindexCannotBeInitiated(message: String) extends CustomError
 case class CancellingReindexFailed(message: String) extends CustomError
 case class RunningJobNotFound(message: String) extends CustomError
+case class ScanamoReadError(message: String) extends CustomError
 
 case class ErrorResponse(errorMessage: String)

--- a/app/com/gu/floodgate/Formats.scala
+++ b/app/com/gu/floodgate/Formats.scala
@@ -2,11 +2,14 @@ package com.gu.floodgate
 
 import com.gu.floodgate.contentsource._
 import com.gu.floodgate.jobhistory._
+import com.gu.floodgate.reindex.BulkJobActor.{ CompletedJobInfo, IsReindexing, PendingJobInfo, RunningJobInfo }
 import com.gu.floodgate.reindex._
 import com.gu.floodgate.runningjob._
 import play.api.libs.json._
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
+
+import scala.concurrent.Future
 
 object Formats {
 
@@ -41,5 +44,10 @@ object Formats {
   implicit val jobHistoryFormat = Json.format[JobHistory]
   implicit val jobHistoriesResponseFormat = Json.format[JobHistoriesResponse]
   implicit val errorResponseFormat = Json.format[ErrorResponse]
+
+  implicit val completedJobInfoFormat = Json.format[CompletedJobInfo]
+  implicit val pendingJobInfoFormat = Json.format[PendingJobInfo]
+  implicit val runningJobInfoFormat = Json.format[RunningJobInfo]
+  implicit val isReindexingFormat = Json.format[IsReindexing]
 
 }

--- a/app/com/gu/floodgate/jobhistory/JobHistoryService.scala
+++ b/app/com/gu/floodgate/jobhistory/JobHistoryService.scala
@@ -6,17 +6,18 @@ import com.gu.scanamo.DynamoFormat
 import com.gu.scanamo.DynamoFormat._
 import org.joda.time.{ DateTime, DateTimeZone }
 
-import scala.concurrent.Future
-import cats.syntax.either._
+import scala.concurrent.{ ExecutionContext, Future }
 
 class JobHistoryService(jobHistoryTable: DynamoDBTable[JobHistory]) {
 
   implicit val dateFormat = DynamoFormat.coercedXmap[DateTime, String, IllegalArgumentException](DateTime.parse(_).withZone(DateTimeZone.UTC))(_.toString)
   implicit val reindexStatusFormat = DynamoFormat.coercedXmap[ReindexStatus, String, IllegalArgumentException](s => ReindexStatus.fromString(s).getOrElse(Unknown))(ReindexStatus.asString)
 
-  def createJobHistory(jobHistory: JobHistory): Unit = jobHistoryTable.saveItem(jobHistory)
+  def createJobHistory(jobHistory: JobHistory): Unit = jobHistoryTable.saveItem[JobHistory](jobHistory)
   def getJobHistories(): Future[Seq[JobHistory]] = jobHistoryTable.getAll()
   def getJobHistoryForContentSource(contentSourceId: String, environment: String): Future[List[JobHistory]] =
     jobHistoryTable.getItemsWithFilter(contentSourceId, filterKeyName = "environment", filterValue = environment): Future[List[JobHistory]]
+
+  def getLatestJob(id: String, env: String)(implicit ec: ExecutionContext): Future[Option[JobHistory]] = jobHistoryTable.getLatestItem(id, filterKeyName = "environment", filterValue = env)
 
 }

--- a/app/com/gu/floodgate/reindex/BulkJobActor.scala
+++ b/app/com/gu/floodgate/reindex/BulkJobActor.scala
@@ -1,0 +1,220 @@
+package com.gu.floodgate.reindex
+
+import akka.actor.{ Actor, ActorLogging, Props }
+import akka.pattern.pipe
+import com.gu.floodgate.{ CustomError, RunningJobNotFound }
+import com.gu.floodgate.contentsource.{ ContentSource, ContentSourceSettings }
+import com.gu.floodgate.jobhistory.JobHistoryService
+import com.gu.floodgate.reindex.BulkJobActor._
+import com.gu.floodgate.runningjob.{ RunningJob, RunningJobService }
+import com.gu.scanamo.DynamoFormat
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.util.{ Failure, Success }
+import org.joda.time.{ DateTime, DateTimeZone }
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+object BulkJobActor {
+
+  def props(contentSources: List[ContentSource], runningJobService: RunningJobService, reindexService: ReindexService, jobHistoryService: JobHistoryService) =
+    Props(new BulkJobActor(contentSources, runningJobService, reindexService, jobHistoryService))
+
+  sealed trait BulkReindexRequestResult
+  sealed trait DropPendingJobResult
+  case object CanTrigger extends BulkReindexRequestResult
+  case object RejectJob extends BulkReindexRequestResult
+
+  case object StartBulkReindex
+  case object ReindexNext
+  case object IsActorReindexing
+
+  case class ReindexStarted(id: String, environment: String)
+  case class ReindexError(id: String, environment: String, error: CustomError)
+  case class Polling(id: String, environment: String)
+
+  case class RunningJobInfo(name: String, id: String, env: String, documentsIndexed: Int, documentsExpected: Int, startTime: DateTime, settings: ContentSourceSettings)
+  case class PendingJobInfo(name: String, id: String, env: String)
+  case class CompletedJobInfo(name: String, id: String, env: String, startTime: DateTime, finishTime: DateTime, status: ReindexStatus)
+
+  case class IsReindexing(runningJobs: Seq[RunningJobInfo], pendingJobs: List[PendingJobInfo], completedJobs: List[CompletedJobInfo]) extends BulkReindexRequestResult
+  case object NotReindexing extends BulkReindexRequestResult
+  case class DropPendingJob(id: String, env: String)
+  case object CancelledPendingJob extends DropPendingJobResult
+  case object FailedToCancelPendingJob extends DropPendingJobResult
+
+}
+
+class BulkJobActor(contentSources: List[ContentSource], runningJobService: RunningJobService, reindexService: ReindexService, jobHistoryService: JobHistoryService) extends Actor with ActorLogging with StrictLogging {
+
+  import context.become
+
+  private def sortContentToReindex: List[ContentSource] = {
+    val helperMap = contentSources.map(content => content.appName -> content).toMap
+    val intersection = desiredReindexOrder.intersect(helperMap.keys.toSeq)
+    intersection.flatMap(contentType => helperMap.get(contentType))
+  }
+
+  private val desiredReindexOrder = List(
+    "Atom Workshop",
+    "Media Atom Maker",
+    "Quizzes",
+    "Interactive atoms",
+    "Explainers",
+    "Packages Editor",
+    "Section Manager",
+    "Tag Manager",
+    "Flexible Content"
+  )
+  private val orderedContentSources = sortContentToReindex
+  private val nameIdMap = orderedContentSources.map(source => (source.id, source.appName)).toMap
+  private var pendingReindexes: List[(String, String)] = Nil // our queue
+  private val PollInterval = 200.milliseconds
+
+  final def receive: Receive = notReindexing
+
+  private def notReindexing: Receive = {
+    case StartBulkReindex => {
+      if (noRunningReindexes) {
+        pendingReindexes = orderedContentSources.map(contentSource => (contentSource.id, contentSource.environment))
+        sender ! CanTrigger
+        become(reindexing)
+        self ! ReindexNext
+      } else {
+        sender ! RejectJob
+      }
+    }
+    case IsActorReindexing => sender ! NotReindexing
+    case other => logger.warn(s"Unexpected message received: $other")
+  }
+
+  private def reindexing: Receive = {
+    case ReindexNext => reindexNextContentSource
+    case ReindexStarted(id, env) => {
+      pendingReindexes = pendingReindexes.filterNot(contentTuple => contentTuple == (id, env))
+      self ! Polling(id, env)
+    }
+    case ReindexError(id, env, error) => {
+      pendingReindexes = Nil
+      val failedReindex = contentSources.find(contentSource => (contentSource.id, contentSource.environment) == (id, env))
+      logger.warn(s"Unable to trigger Reindex for ${failedReindex}")
+      become(notReindexing)
+    }
+    case Polling(id, env) => pollRunningReindexes(id, env)
+    case IsActorReindexing => buildReindexInfo pipeTo sender()
+    case DropPendingJob(id, env) => {
+      pendingReindexes = pendingReindexes.filterNot(contentTuple => (id, env) == contentTuple)
+      if (pendingReindexes.contains((id, env)) || runningJobService.getRunningJob(id, env).isRight) {
+        sender ! FailedToCancelPendingJob
+      } else {
+        sender ! CancelledPendingJob
+      }
+    }
+  }
+
+  private def buildReindexInfo: Future[IsReindexing] = {
+
+    val futureRunningJobs = getRunningJobs
+    val futureCompletedJobs = getCompletedJobs
+
+    for {
+      runningJobs <- futureRunningJobs
+      completedJobs <- futureCompletedJobs
+      pendingJobs = getPendingJobs
+    } yield {
+      IsReindexing(runningJobs, pendingJobs, completedJobs)
+    }
+  }
+
+  private def getRunningJobs = {
+    val env = orderedContentSources.map(source => source.environment).distinct
+    val futureRunningJobs = runningJobService.getAllRunningJobs().map(jobs => jobs.filter(job => env.contains(job.contentSourceEnvironment)))
+    futureRunningJobs.map { runningJobs =>
+      runningJobs.map { job =>
+        val name = nameIdMap.get(job.contentSourceId).getOrElse(s"Name not found for ID: ${job.contentSourceId}")
+        val contentSource = orderedContentSources.find(contentSource => (contentSource.id, contentSource.environment) == (job.contentSourceId, job.contentSourceEnvironment))
+        contentSource match {
+          case None => {
+            logger.warn(s"Unable to find corresponding contentSource for ${name}. Set settings to false, you will be unable to cancel.")
+            RunningJobInfo(
+              name,
+              job.contentSourceId,
+              job.contentSourceEnvironment,
+              job.documentsIndexed,
+              job.documentsExpected,
+              job.startTime,
+              ContentSourceSettings(false, false)
+            )
+          }
+          case Some(source) => RunningJobInfo(
+            name,
+            job.contentSourceId,
+            job.contentSourceEnvironment,
+            job.documentsIndexed,
+            job.documentsExpected,
+            job.startTime,
+            source.contentSourceSettings
+          )
+        }
+      }
+    }
+  }
+  private def getCompletedJobs = {
+
+    val pendingReindexesIds = pendingReindexes.map((tuple) => tuple._1).toSet
+    val completedIds = orderedContentSources.map(source => source.id).filterNot(pendingReindexesIds)
+    val completedContentSources = orderedContentSources.filter(contentSource => completedIds.contains(contentSource.id))
+
+    val result = Future.sequence(completedContentSources.map { source =>
+      jobHistoryService.getLatestJob(source.id, source.environment).map { maybeJobHistory =>
+        maybeJobHistory.map { jobHistory =>
+          CompletedJobInfo(source.appName, source.id, source.environment, jobHistory.startTime, jobHistory.finishTime, jobHistory.status)
+        }
+      }
+    })
+
+    result.map(list => list.flatten)
+
+  }
+
+  private def getPendingJobs = {
+    val pendingReindexesSources = orderedContentSources.filter { contentSource =>
+      val ids = pendingReindexes.flatMap(tuple => List(tuple._1))
+      ids.contains(contentSource.id)
+    }
+    pendingReindexesSources.map(pendingSource => PendingJobInfo(pendingSource.appName, pendingSource.id, pendingSource.environment))
+  }
+
+  private def reindexNextContentSource: Unit = {
+    pendingReindexes match {
+      case Nil => become(notReindexing)
+      case (id, env) :: xs => {
+        reindexService.reindex(id, env, new DateParameters(None, None)).map {
+          case Left(error) => self ! ReindexError(id, env, error)
+          case Right(runningJob) => self ! ReindexStarted(id, env)
+        }
+      }
+    }
+  }
+
+  private def pollRunningReindexes(id: String, environment: String): Unit = {
+    runningJobService.getRunningJob(id, environment) match {
+      case Left(RunningJobNotFound(_)) => self ! ReindexNext
+      case Left(error: CustomError) => logger.warn(s"Job present in table, but failed to read: ${error.message}")
+      case Right(job) => context.system.scheduler.scheduleOnce(PollInterval, self, Polling(id, environment))
+    }
+  }
+
+  private def noRunningReindexes: Boolean = {
+    val maybeRunningJob = contentSources.find { contentSource =>
+      runningJobService.getRunningJob(contentSource.id, contentSource.environment) match {
+        case Left(RunningJobNotFound(_)) => false
+        case _ => true
+      }
+    }
+    maybeRunningJob.isEmpty
+  }
+
+}

--- a/app/com/gu/floodgate/runningjob/RunningJobService.scala
+++ b/app/com/gu/floodgate/runningjob/RunningJobService.scala
@@ -1,9 +1,10 @@
 package com.gu.floodgate.runningjob
 
 import cats.syntax.either._
-import com.gu.floodgate.{ ContentSourceNotFound, RunningJobNotFound, CustomError, DynamoDBTable }
+import com.gu.floodgate._
 import com.gu.scanamo.DynamoFormat
-import org.joda.time.{ DateTimeZone, DateTime }
+import org.joda.time.{ DateTime, DateTimeZone }
+
 import scala.concurrent.Future
 
 class RunningJobService(runningJobTable: DynamoDBTable[RunningJob]) {
@@ -18,7 +19,7 @@ class RunningJobService(runningJobTable: DynamoDBTable[RunningJob]) {
 
   def getRunningJob(contentSourceId: String, contentSourceEnvironment: String): Either[CustomError, RunningJob] =
     runningJobTable.getItem[RunningJob](contentSourceId, contentSourceEnvironment) match {
-      case Some(result) => result.leftMap(err => RunningJobNotFound(s"A running job for content source with id: $contentSourceId and environment: $contentSourceEnvironment does not exist."))
-      case None => Left(ContentSourceNotFound(s"A running job for content source with id: $contentSourceId and environment: $contentSourceEnvironment does not exist."))
+      case Some(result) => result.leftMap(err => ScanamoReadError(s"There was a DynamoRead error for content with id: $contentSourceId and environment: $contentSourceEnvironment: $err"))
+      case None => Left(RunningJobNotFound(s"A running job for content source with id: $contentSourceId and environment: $contentSourceEnvironment does not exist."))
     }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,3 +1,5 @@
+env="TEST"
+
 play.http.secret.key = "changeme"
 play.http.secret.key = ${?CRYPTO_SECRET}
 play.i18n.langs = [ "en" ]

--- a/conf/routes
+++ b/conf/routes
@@ -14,6 +14,8 @@ GET         /loginAction                                                  contro
 GET         /oauth2callback                                               controllers.Login.oauth2Callback
 
 # Api
+GET         /content-source/bulk-status                                   com.gu.floodgate.contentsource.ContentSourceApi.checkIfInBulkMode
+POST        /content-source/bulk-reindexer                                com.gu.floodgate.contentsource.ContentSourceApi.startBulkReindexer
 GET         /content-source                                               com.gu.floodgate.contentsource.ContentSourceApi.getAllContentSources
 GET         /content-source/:id                                           com.gu.floodgate.contentsource.ContentSourceApi.getContentSources(id)
 GET         /content-source/:id/:environment                              com.gu.floodgate.contentsource.ContentSourceApi.getContentSource(id, environment)
@@ -21,6 +23,7 @@ POST        /content-source                                               com.gu
 PUT         /content-source/:id/:environment                              com.gu.floodgate.contentsource.ContentSourceApi.updateContentSource(id, environment)
 DELETE      /content-source/:id                                           com.gu.floodgate.contentsource.ContentSourceApi.deleteContentSource(id)
 POST        /content-source/:id/:environment/reindex                      com.gu.floodgate.contentsource.ContentSourceApi.reindex(id, environment, from: Option[String] ?= None, to: Option[String] ?= None)
+DELETE      /content-source/:id/:environment/pending-reindex              com.gu.floodgate.contentsource.ContentSourceApi.cancelPendingReindex(id, environment)
 DELETE      /content-source/:id/:environment/reindex                      com.gu.floodgate.contentsource.ContentSourceApi.cancelReindex(id, environment)
 GET         /content-source/:id/:environment/reindex/history              com.gu.floodgate.contentsource.ContentSourceApi.getReindexHistory(id, environment)
 GET         /content-source/:id/:environment/reindex/running              com.gu.floodgate.contentsource.ContentSourceApi.getRunningReindex(id, environment)

--- a/conf/routes
+++ b/conf/routes
@@ -14,9 +14,9 @@ GET         /loginAction                                                  contro
 GET         /oauth2callback                                               controllers.Login.oauth2Callback
 
 # Api
+GET         /content-source                                               com.gu.floodgate.contentsource.ContentSourceApi.getAllContentSources
 GET         /content-source/bulk-status                                   com.gu.floodgate.contentsource.ContentSourceApi.checkIfInBulkMode
 POST        /content-source/bulk-reindexer                                com.gu.floodgate.contentsource.ContentSourceApi.startBulkReindexer
-GET         /content-source                                               com.gu.floodgate.contentsource.ContentSourceApi.getAllContentSources
 GET         /content-source/:id                                           com.gu.floodgate.contentsource.ContentSourceApi.getContentSources(id)
 GET         /content-source/:id/:environment                              com.gu.floodgate.contentsource.ContentSourceApi.getContentSource(id, environment)
 POST        /content-source                                               com.gu.floodgate.contentsource.ContentSourceApi.createContentSources

--- a/public/components/bulkReindexController.react.js
+++ b/public/components/bulkReindexController.react.js
@@ -1,0 +1,208 @@
+import React from 'react';
+import BulkReindex from './bulkReindexes.react';
+import ContentSourceService from '../services/contentSourceService';
+import { Label, Row, Col, Panel, Input, Button, ButtonToolbar, Alert } from 'react-bootstrap';
+
+export default class BulkReindexControllerComponent extends React.Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            contentSources: [],
+            runningReindexes: [],
+            pendingReindexes: [],
+            completedReindexes: [],
+            editModeOn: false,
+            inBulkMode: false,
+            reindexLiveStack: true,
+            reindexPreviewStack: true,
+            reindexProd: true,
+            reindexCode: true,
+            alertStyle: 'success',
+            alertMessage: '',
+            alertVisibility: false
+        };
+
+        this.generateEnvironments = this.generateEnvironments.bind(this);
+        this.requestBulkStatus = this.requestBulkStatus.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+        this.initiateBulkReindex = this.initiateBulkReindex.bind(this);
+        this.checkRunningReindexes = this.checkRunningReindexes.bind(this);
+    }
+
+    componentDidMount() {
+        this.checkRunningReindexes();
+        setInterval(this.checkRunningReindexes, 30000);
+    }
+
+    initiateBulkReindex(environments) {
+        if (environments.length > 0) {
+            ContentSourceService.initiateBulkReindexer(environments)
+        } else {
+            console.log("Error: No content selected to be reindexed.")
+        }
+    }
+
+    requestBulkStatus() {
+        return ContentSourceService.requestBulkStatus();
+    }
+
+    generateEnvironments() {
+        const desiredEnvironments = [
+            this.state.reindexPreviewStack && this.state.reindexCode ? "draft-code" : "",
+            this.state.reindexPreviewStack && this.state.reindexProd ? "draft-prod" : "",
+            this.state.reindexLiveStack && this.state.reindexCode ? "live-code" : "",
+            this.state.reindexLiveStack && this.state.reindexProd ? "live-prod" : ""
+        ].filter(Boolean);
+        return desiredEnvironments;
+    }
+
+    loadRunningReindexes(json) {
+
+        const r = (acc, v) => acc.concat(v);
+        const f = (s) => (o) => o[s];
+        const getPendingJobs = f('pendingJobs');
+        const getRunningJobs = f('runningJobs');
+        const getCompletedJobs = f('completedJobs');
+
+        let pendingReindexes = Object.values(json.data).map(getPendingJobs).reduce(r, []);
+        let runningReindexes = Object.values(json.data).map(getRunningJobs).reduce(r, []);
+        let completedReindexes = Object.values(json.data).map(getCompletedJobs).reduce(r, []);
+
+        this.setState({
+                runningReindexes: runningReindexes,
+                pendingReindexes: pendingReindexes,
+                completedReindexes: completedReindexes,
+                alertVisibility: false,
+            });
+
+        this.requestBulkStatus();
+    }
+
+    checkRunningReindexes() {
+        this.requestBulkStatus().then(response => {
+            var json = JSON.parse(response);
+            var reindexInProgress =  json.IsReindexing;
+            if (!reindexInProgress) {
+                this.setState({
+                    inBulkMode: false
+                });
+            } else {
+                this.loadRunningReindexes(json);
+                this.setState({
+                    inBulkMode: true
+                });
+            }
+        });
+    }
+
+    cancelReindex(reindex, isReindexRunning) {
+        if (isReindexRunning) {
+            ContentSourceService.cancelReindex(reindex.id, reindex.env).then( response => {
+                    this.setState({
+                        runningReindexes: this.state.runningReindexes.filter(r => r !== reindex)
+                    });
+                },
+                errors => {
+                    this.setState({alertStyle: 'danger', alertMessage: 'Failed to cancel running reindex for '+ reindex.name, alertVisibility: true});
+                });
+        } else {
+            ContentSourceService.cancelPendingReindex(reindex.id, reindex.env).then( response => {
+                this.setState({
+                    pendingReindexes: this.state.pendingReindexes.filter(r => r !== reindex)
+                });
+            },
+                errors => {
+                    this.setState({alertStyle: 'danger', alertMessage: 'Failed to cancel pending reindex for ' + reindex.name, alertVisibility: true});
+                });
+        }
+    }
+
+    handleSubmit(e) {
+        e.preventDefault();
+        this.requestBulkStatus().then(response => {
+            var json = JSON.parse(response);
+            var reindexInProgress =  json.IsReindexing;
+            if (!reindexInProgress) {
+                let environments = this.generateEnvironments();
+                this.setState({alertStyle: 'success', alertMessage: 'Bulk job submitted.', alertVisibility: true});
+                this.initiateBulkReindex(environments);
+            } else {
+                this.setState({alertStyle: 'danger', alertMessage: 'Bulk job in progress. Please wait till job has finished.', alertVisibility: true});
+            }
+        });
+    }
+
+    handleReindexLiveStack(e) {
+        this.setState({reindexLiveStack: e.target.checked});
+    }
+
+    handleReindexPreviewStack(e) {
+        this.setState({reindexPreviewStack: e.target.checked});
+    }
+
+    handleReindexProd(e) {
+        this.setState({reindexProd: e.target.checked});
+    }
+
+    handleReindexCode(e) {
+        this.setState({reindexCode: e.target.checked});
+    }
+
+    render () {
+
+        return (
+            <div id="page-wrapper">
+                <div className="container-fluid">
+                    <div>
+                        { this.state.alertVisibility ? <Alert bsStyle={this.state.alertStyle}>{this.state.alertMessage}</Alert> : null }
+                        <form className="form-horizontal" onSubmit={this.handleSubmit}>
+                            <Row>
+                                <Col xs={12} md={12}>
+                                    <h3><Label>Reindexer</Label></h3>
+                                    <Panel header="Start Reindex">
+                                        <Input label="Stack" labelClassName="col-xs-2" wrapperClassName="wrapper">
+                                            <Col xs={5}>
+                                                <Input type="checkbox" defaultChecked={this.state.reindexLiveStack} onChange={this.handleReindexLiveStack.bind(this)} label="Live" />
+                                            </Col>
+                                            <Col xs={5}>
+                                                <Input type="checkbox" defaultChecked={this.state.reindexPreviewStack} onChange={this.handleReindexPreviewStack.bind(this)} label="Preview" />
+                                            </Col>
+                                        </Input>
+                                        <Input label="Stage" labelClassName="col-xs-2" wrapperClassName="wrapper">
+                                            <Col xs={5}>
+                                                <Input type="checkbox" defaultChecked={this.state.reindexProd} onChange={this.handleReindexProd.bind(this)} label="PROD" />
+                                            </Col>
+                                            <Col xs={5}>
+                                                <Input type="checkbox" defaultChecked={this.state.reindexCode} onChange={this.handleReindexCode.bind(this)} label="CODE" />
+                                            </Col>
+                                        </Input>
+                                        <ButtonToolbar>
+                                            <Button bsStyle="success" className="pull-right" type="submit">Reindex</Button>
+                                        </ButtonToolbar>
+                                    </Panel>
+                                </Col>
+                            </Row>
+                        </form>
+                    </div>
+                    <div>
+                        <Row>
+                            <Col xs={12} md={12}>
+                                    { (!this.state.inBulkMode) ?
+                                        <p>There are no bulk reindexes currently in progress.</p>
+                                    :
+                                        <BulkReindex completedReindexes={this.state.completedReindexes}
+                                                       runningReindexes={this.state.runningReindexes}
+                                                       pendingReindexes={this.state.pendingReindexes}
+                                                       onReloadRunningReindex={this.checkRunningReindexes.bind(this)}
+                                                       onCancelReindex={this.cancelReindex.bind(this)}/>
+                                    }
+                            </Col>
+                        </Row>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/public/components/bulkReindexController.react.js
+++ b/public/components/bulkReindexController.react.js
@@ -29,16 +29,26 @@ export default class BulkReindexControllerComponent extends React.Component {
         this.handleSubmit = this.handleSubmit.bind(this);
         this.initiateBulkReindex = this.initiateBulkReindex.bind(this);
         this.checkRunningReindexes = this.checkRunningReindexes.bind(this);
+        this.handleReindexLiveStack = this.handleReindexLiveStack.bind(this);
+        this.handleReindexPreviewStack = this.handleReindexPreviewStack.bind(this);
+        this.handleReindexCode = this.handleReindexCode.bind(this);
+        this.handleReindexProd = this.handleReindexProd.bind(this);
+        this.cancelReindex = this.cancelReindex.bind(this);
     }
 
     componentDidMount() {
-        this.checkRunningReindexes();
-        setInterval(this.checkRunningReindexes, 30000);
+        let intervalPeriod = 1000;
+        setInterval(this.checkRunningReindexes, intervalPeriod);
     }
 
     initiateBulkReindex(environments) {
         if (environments.length > 0) {
-            ContentSourceService.initiateBulkReindexer(environments)
+            ContentSourceService.initiateBulkReindexer(environments).then (response => {
+                this.checkRunningReindexes()
+                },
+            errors => {
+                this.setState({alertStyle: 'danger', alertMessage: 'Failed to trigger reindexes for '+ environments, alertVisibility: true});
+            });
         } else {
             console.log("Error: No content selected to be reindexed.")
         }
@@ -82,8 +92,8 @@ export default class BulkReindexControllerComponent extends React.Component {
 
     checkRunningReindexes() {
         this.requestBulkStatus().then(response => {
-            var json = JSON.parse(response);
-            var reindexInProgress =  json.IsReindexing;
+            let json = JSON.parse(response);
+            let reindexInProgress =  json.IsReindexing;
             if (!reindexInProgress) {
                 this.setState({
                     inBulkMode: false
@@ -160,22 +170,22 @@ export default class BulkReindexControllerComponent extends React.Component {
                         <form className="form-horizontal" onSubmit={this.handleSubmit}>
                             <Row>
                                 <Col xs={12} md={12}>
-                                    <h3><Label>Reindexer</Label></h3>
+                                    <h3><Label>Bulk Reindexer</Label></h3>
                                     <Panel header="Start Reindex">
                                         <Input label="Stack" labelClassName="col-xs-2" wrapperClassName="wrapper">
                                             <Col xs={5}>
-                                                <Input type="checkbox" defaultChecked={this.state.reindexLiveStack} onChange={this.handleReindexLiveStack.bind(this)} label="Live" />
+                                                <Input type="checkbox" defaultChecked={this.state.reindexLiveStack} onChange={this.handleReindexLiveStack} label="Live" />
                                             </Col>
                                             <Col xs={5}>
-                                                <Input type="checkbox" defaultChecked={this.state.reindexPreviewStack} onChange={this.handleReindexPreviewStack.bind(this)} label="Preview" />
+                                                <Input type="checkbox" defaultChecked={this.state.reindexPreviewStack} onChange={this.handleReindexPreviewStack} label="Preview" />
                                             </Col>
                                         </Input>
                                         <Input label="Stage" labelClassName="col-xs-2" wrapperClassName="wrapper">
                                             <Col xs={5}>
-                                                <Input type="checkbox" defaultChecked={this.state.reindexProd} onChange={this.handleReindexProd.bind(this)} label="PROD" />
+                                                <Input type="checkbox" defaultChecked={this.state.reindexProd} onChange={this.handleReindexProd} label="PROD" />
                                             </Col>
                                             <Col xs={5}>
-                                                <Input type="checkbox" defaultChecked={this.state.reindexCode} onChange={this.handleReindexCode.bind(this)} label="CODE" />
+                                                <Input type="checkbox" defaultChecked={this.state.reindexCode} onChange={this.handleReindexCode} label="CODE" />
                                             </Col>
                                         </Input>
                                         <ButtonToolbar>
@@ -195,8 +205,8 @@ export default class BulkReindexControllerComponent extends React.Component {
                                         <BulkReindex completedReindexes={this.state.completedReindexes}
                                                        runningReindexes={this.state.runningReindexes}
                                                        pendingReindexes={this.state.pendingReindexes}
-                                                       onReloadRunningReindex={this.checkRunningReindexes.bind(this)}
-                                                       onCancelReindex={this.cancelReindex.bind(this)}/>
+                                                       onReloadRunningReindex={this.checkRunningReindexes}
+                                                       onCancelReindex={this.cancelReindex}/>
                                     }
                             </Col>
                         </Row>

--- a/public/components/bulkReindexes.react.js
+++ b/public/components/bulkReindexes.react.js
@@ -21,8 +21,9 @@ export default class BulkReindex extends React.Component {
         if (isRunningJob && !reindex.settings.supportsCancelReindex) {
             return (null);
         } else {
+            var cancelWithReindexData = this.cancelReindex.bind(reindex, isRunningJob)
             return (
-                <Button bsStyle="danger" className="pull-right" type="button" onClick={this.cancelReindex.bind(this, reindex, isRunningJob)}>Cancel</Button>
+                <Button bsStyle="danger" className="pull-right" type="button" onClick={cancelWithReindexData} data-reindex={reindex}>Cancel</Button>
             );
         }
     }
@@ -54,7 +55,7 @@ export default class BulkReindex extends React.Component {
                                         startTime={runningJob.startTime}
                                         reindex={runningJob}
                                         isCancelSupported={false}
-                                        onCancelReindex={this.cancelReindex.bind(this)}
+                                        onCancelReindex={ () => {} }
                                         onReloadRunningReindex={this.props.onReloadRunningReindex}/>
                     </td>
                     <td>{new Date(runningJob.startTime).toUTCString()}</td>

--- a/public/components/bulkReindexes.react.js
+++ b/public/components/bulkReindexes.react.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import { Panel, Button, Table } from 'react-bootstrap';
+import RunningReindex from './runningReindex.react';
+
+
+export default class BulkReindex extends React.Component {
+
+    constructor(props) {
+        super(props);
+
+        this.cancelReindex = this.cancelReindex.bind(this);
+        this.renderCancelButton = this.renderCancelButton.bind(this);
+    }
+
+
+    cancelReindex(reindex, isRunningJob) {
+        this.props.onCancelReindex(reindex, isRunningJob);
+    }
+
+    renderCancelButton(reindex, isRunningJob) {
+        if (isRunningJob && !reindex.settings.supportsCancelReindex) {
+            return (null);
+        } else {
+            return (
+                <Button bsStyle="danger" className="pull-right" type="button" onClick={this.cancelReindex.bind(this, reindex, isRunningJob)}>Cancel</Button>
+            );
+        }
+    }
+
+    render () {
+
+        const completedJobsNodes = this.props.completedReindexes.map(completedJob => {
+            return (
+                <tr key={completedJob.startTime}>
+                    <td>{completedJob.name}</td>
+                    <td>{completedJob.env}</td>
+                    <td>{completedJob.status}</td>
+                    <td>{new Date(completedJob.startTime).toUTCString()}</td>
+                    <td>{new Date(completedJob.finishTime).toUTCString()}</td>
+                </tr>
+            );
+        });
+
+        const runningJobsNodes = this.props.runningReindexes.map(runningJob => {
+            return (
+                <tr key={runningJob.startTime}>
+                    <td>{runningJob.name}</td>
+                    <td>{runningJob.env}</td>
+                    <td>
+                        <RunningReindex documentsIndexes={runningJob.documentsIndexed}
+                                        documentsExpected={runningJob.documentsExpected}
+                                        environment={runningJob.env}
+                                        id={runningJob.id}
+                                        startTime={runningJob.startTime}
+                                        reindex={runningJob}
+                                        isCancelSupported={false}
+                                        onCancelReindex={this.cancelReindex.bind(this)}
+                                        onReloadRunningReindex={this.props.onReloadRunningReindex}/>
+                    </td>
+                    <td>{new Date(runningJob.startTime).toUTCString()}</td>
+                    <td>-</td>
+                    <td>{ this.renderCancelButton(runningJob, true) }</td>
+                </tr>
+            );
+        });
+
+        const pendingJobsNodes = this.props.pendingReindexes.map(pendingJob => {
+            return (
+                <tr key={pendingJob.id + pendingJob.env}>
+                    <td>{pendingJob.name}</td>
+                    <td>{pendingJob.env}</td>
+                    <td>Pending</td>
+                    <td>-</td>
+                    <td>-</td>
+                    <td>{ this.renderCancelButton(pendingJob, false) }</td>
+                </tr>
+            );
+        });
+
+        return (
+            <Panel header="Running Reindexes">
+                <Table striped hover fill>
+                    <thead>
+                    <tr>
+                        <th>App</th>
+                        <th>Environment</th>
+                        <th>Status</th>
+                        <th>Start Time</th>
+                        <th>Finish Time</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                        {completedJobsNodes}
+                    </tbody>
+                    <tbody>
+                        {runningJobsNodes}
+                    </tbody>
+                    <tbody>
+                        {pendingJobsNodes}
+                    </tbody>
+                </Table>
+            </Panel>
+        );
+    }
+}

--- a/public/components/navigation.react.js
+++ b/public/components/navigation.react.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import R from 'ramda';
 import { Link } from 'react-router';
-import { Navbar, Nav, NavItem, NavDropdown, MenuItem, Label } from 'react-bootstrap'
+import { Navbar, Nav, NavItem, NavDropdown, MenuItem } from 'react-bootstrap'
 
 export default class NavigationComponent extends React.Component {
 
@@ -33,10 +33,10 @@ export default class NavigationComponent extends React.Component {
                 <Navbar.Collapse>
                     <Nav>
                         <NavItem eventKey={1} href="#/register">Register</NavItem>
-                        <NavDropdown eventKey={2} title="Content sources" id="nav-content-source-dropdown">
+                        <NavItem eventKey={2} href="#/bulk">Bulk Reindexer</NavItem>
+                        <NavDropdown eventKey={3} title="Content sources" id="nav-content-source-dropdown">
                             {contentSourceNodes}
                         </NavDropdown>
-                        <NavItem eventKey={3} href="#/test">Test</NavItem>
                     </Nav>
                 </Navbar.Collapse>
             </Navbar>

--- a/public/components/navigation.react.js
+++ b/public/components/navigation.react.js
@@ -36,6 +36,7 @@ export default class NavigationComponent extends React.Component {
                         <NavDropdown eventKey={2} title="Content sources" id="nav-content-source-dropdown">
                             {contentSourceNodes}
                         </NavDropdown>
+                        <NavItem eventKey={3} href="#/test">Test</NavItem>
                     </Nav>
                 </Navbar.Collapse>
             </Navbar>

--- a/public/components/reindexController.react.js
+++ b/public/components/reindexController.react.js
@@ -46,6 +46,7 @@ export default class ReindexControllerComponent extends React.Component {
 
     loadContentSourceWithId(id, environment) {
         ContentSourceService.getContentSourcesWithId(id).then(response => {
+            console.log(response.contentSources);
             const contentSources = response.contentSources.reverse();
             this.setState({
                 contentSourcesForEnvironments: contentSources
@@ -174,7 +175,12 @@ export default class ReindexControllerComponent extends React.Component {
                                  R.isNil(this.state.contentSource.contentSourceSettings) || R.isEmpty(Object.keys(this.state.contentSource)) ?
                                     <p>There are no reindexes currently in progress.</p>
                                     :
-                                    <RunningReindex data={this.state.runningReindex}
+                                    <RunningReindex documentsIndexes={this.state.runningReindex.documentsIndexed}
+                                                    documentsExpected={this.state.runningReindex.documentsExpected}
+                                                    environment={this.state.runningReindex.contentSourceEnvironment}
+                                                    id={this.state.runningReindex.contentSourceId}
+                                                    startTime={this.state.runningReindex.startTime}
+                                                    reindex={this.state.runningReindex}
                                                     isCancelSupported={this.state.contentSource.contentSourceSettings.supportsCancelReindex}
                                                     onCancelReindex={this.cancelReindex.bind(this)}
                                                     onReloadRunningReindex={this.loadRunningReindex.bind(this)}/>

--- a/public/components/reindexController.react.js
+++ b/public/components/reindexController.react.js
@@ -46,7 +46,6 @@ export default class ReindexControllerComponent extends React.Component {
 
     loadContentSourceWithId(id, environment) {
         ContentSourceService.getContentSourcesWithId(id).then(response => {
-            console.log(response.contentSources);
             const contentSources = response.contentSources.reverse();
             this.setState({
                 contentSourcesForEnvironments: contentSources

--- a/public/components/runningReindex.react.js
+++ b/public/components/runningReindex.react.js
@@ -19,21 +19,21 @@ export default class RunningReindex extends React.Component {
 
     componentDidMount() {
         this.setState({
-            progress: this.computeProgress( this.props.data.documentsIndexed, this.props.data.documentsExpected),
+            progress: this.computeProgress( this.props.documentsIndexed, this.props.documentsExpected),
             progressUpdatesEnabled: true
         });
     }
 
     componentWillReceiveProps(nextProps) {
         this.setState({
-            progress: this.computeProgress( nextProps.data.documentsIndexed, nextProps.data.documentsExpected),
+            progress: this.computeProgress( nextProps.documentsIndexed, nextProps.documentsExpected),
             progressUpdatesEnabled: true
         });
     }
 
     updateRunningReindex() {
-        const contentSourceId = this.props.data.contentSourceId;
-        const environment = this.props.data.contentSourceEnvironment;
+        const contentSourceId = this.props.id;
+        const environment = this.props.environment;
         this.props.onReloadRunningReindex(contentSourceId, environment);
     }
 
@@ -47,7 +47,7 @@ export default class RunningReindex extends React.Component {
     }
 
     cancelReindex() {
-        const runningReindex = this.props.data;
+        const runningReindex = this.props.reindex;
         this.props.onCancelReindex(runningReindex);
     }
 
@@ -67,7 +67,7 @@ export default class RunningReindex extends React.Component {
         var timeout = 2000;
 
         return (
-            <div key={this.props.data.startTime}>
+            <div key={this.props.startTime}>
                 <ReactInterval timeout={this.timeout} enabled={this.state.progressUpdatesEnabled}
                                callback={ this.updateRunningReindex.bind(this) } />
                 <ProgressBar striped active now={this.state.progress} label="%(percent)s%"/>

--- a/public/routes/routes.js
+++ b/public/routes/routes.js
@@ -1,17 +1,16 @@
 import React from 'react';
-import { Route, IndexRoute } from 'react-router';
+import { Route, IndexRedirect } from 'react-router';
 
 import ReactApp from '../components/reactApp.react';
 import ReindexController from '../components/reindexController.react.js';
 import Register from '../components/register.react.js';
-import Home from '../components/home.react';
 import BulkReindexController from '../components/bulkReindexController.react.js';
 
 export default [
     <Route path="/" component={ReactApp}>
+        <IndexRedirect to="/bulk" />
+        <Route name="bulk reindexer" path="/bulk" component={BulkReindexController} />
         <Route name="reindex" path="/reindex/:id/environment/:environment" component={ReindexController} />
         <Route name="register" path="/register" component={Register} />
-        <Route name="test" path="/test" component={BulkReindexController} />
-        <IndexRoute component={Home}/>
     </Route>
 ];

--- a/public/routes/routes.js
+++ b/public/routes/routes.js
@@ -5,11 +5,13 @@ import ReactApp from '../components/reactApp.react';
 import ReindexController from '../components/reindexController.react.js';
 import Register from '../components/register.react.js';
 import Home from '../components/home.react';
+import BulkReindexController from '../components/bulkReindexController.react.js';
 
 export default [
     <Route path="/" component={ReactApp}>
         <Route name="reindex" path="/reindex/:id/environment/:environment" component={ReindexController} />
         <Route name="register" path="/register" component={Register} />
+        <Route name="test" path="/test" component={BulkReindexController} />
         <IndexRoute component={Home}/>
     </Route>
 ];

--- a/public/services/contentSourceService.js
+++ b/public/services/contentSourceService.js
@@ -65,9 +65,34 @@ export default {
         })
     },
 
+    initiateBulkReindexer:(env) => {
+        return Reqwest({
+            url: '/content-source/' + 'bulk-reindexer',
+            contentType: 'text/json',
+            method: 'post',
+            data: JSON.stringify({ environments: env })
+
+        })
+    },
+
+    requestBulkStatus:() => {
+        return Reqwest({
+            url: '/content-source/' + 'bulk-status',
+            contentType: 'text/json',
+            method: 'get'
+        })
+    },
+
     cancelReindex:(id, environment) => {
         return Reqwest({
             url: '/content-source/' + id + '/' + environment + '/reindex',
+            method: 'delete'
+        })
+    },
+
+    cancelPendingReindex:(id, environment) => {
+        return Reqwest({
+            url: '/content-source/' + id + '/' + environment + '/pending-reindex',
             method: 'delete'
         })
     }


### PR DESCRIPTION
This change provides the ability to:
- Trigger bulk reindexes by `stack-stage`
- Have reindexes run in different environments in parallel
- Will not run if manual reindexes are in progress
- Will not allow reindexes to be ran in bulk mode
- Cancel individual running & pending reindexes

**To do:** 
- [x] Triggered using `CODE` content sources
- [x] Tested on `PROD` with `CODE` content sources

Below is an example of the reindexes list:

![screen shot 2017-07-28 at 11 08 16](https://user-images.githubusercontent.com/14946184/28727291-3e39ab0a-73bc-11e7-999f-a41d732ae940.png)
