### PR TITLE
Bug fix: Trigger failure of hanging reindexes

### DIFF
--- a/app/com/gu/floodgate/reindex/ProgressTracker.scala
+++ b/app/com/gu/floodgate/reindex/ProgressTracker.scala
@@ -1,16 +1,16 @@
 package com.gu.floodgate.reindex
 
-import akka.actor.{Actor, ActorLogging, Cancellable, Props}
+import akka.actor.{ Actor, ActorLogging, Cancellable, Props }
 import com.gu.floodgate.contentsource.ContentSource
-import com.gu.floodgate.jobhistory.{JobHistory, JobHistoryService}
-import com.gu.floodgate.reindex.ProgressTracker.{Cancel, TrackProgress, UpdateProgress}
-import com.gu.floodgate.runningjob.{RunningJob, RunningJobService}
+import com.gu.floodgate.jobhistory.{ JobHistory, JobHistoryService }
+import com.gu.floodgate.reindex.ProgressTracker.{ Cancel, TrackProgress, UpdateProgress }
+import com.gu.floodgate.runningjob.{ RunningJob, RunningJobService }
 import com.typesafe.scalalogging.StrictLogging
-import org.joda.time.{DateTime, Minutes}
-import play.api.libs.ws.{WSClient, WSResponse}
+import org.joda.time.{ DateTime, Minutes }
+import play.api.libs.ws.{ WSClient, WSResponse }
 
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 import com.gu.floodgate.Formats._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/public/components/bulkReindexController.react.js
+++ b/public/components/bulkReindexController.react.js
@@ -37,7 +37,7 @@ export default class BulkReindexControllerComponent extends React.Component {
     }
 
     componentDidMount() {
-        let intervalPeriod = 1000;
+        let intervalPeriod = 5000;
         setInterval(this.checkRunningReindexes, intervalPeriod);
     }
 


### PR DESCRIPTION
Previously, if a reindex would stall or hang without reindexing documents, then the job would just continue to persist in the `RunningJobs` table. With the updated ability to trigger bulk reindexes dependant on an empty running jobs queue, bulk reindexes would never trigger if a previous job had stalled.

This fix includes a check for whether the job has ran for a certain period without indexing documents. It also fixes an introduced bug in the `BulkActor` where completed jobs were determined by whether they were the latest job in the `JobHistory` table. If a manual reindex was ran immediately beforehand for the same content source & environment, then the job will always be considered to be completed.

Tested on `CODE`
 