### PR TITLE
Make sure status is properly decoded

### DIFF
--- a/app/com/gu/floodgate/reindex/Progress.scala
+++ b/app/com/gu/floodgate/reindex/Progress.scala
@@ -12,7 +12,7 @@ object ReindexStatus {
     case Unknown => "unknown"
   }
 
-  def fromString(s: String): Option[ReindexStatus] = s match {
+  def fromString(s: String): Option[ReindexStatus] = s.toLowerCase match {
     case "in progress" => Some(InProgress)
     case "failed" => Some(Failed)
     case "completed" => Some(Completed)


### PR DESCRIPTION
The Status of a reindex job is serialised with a capital initial letter, but matched against an all-lowercase one during deserialisation. As a result, the last jobs are marked as "unknown" in the console:

![Screenshot 2019-04-17 at 17 24 54](https://user-images.githubusercontent.com/629976/56304299-c0f5b580-6135-11e9-8a4f-69d633f9145a.png)

Now:

![Screenshot 2019-04-17 at 17 25 37](https://user-images.githubusercontent.com/629976/56304342-d66adf80-6135-11e9-8adb-5f2e27c119a6.png)
