### PR TITLE
Increase max heap size

### DIFF
--- a/content-api-floodgate.service
+++ b/content-api-floodgate.service
@@ -6,7 +6,7 @@ User=content-api
 Group=content-api
 Restart=on-failure
 Environment='HOME=/home/content-api'
-Environment='JAVA_OPTS=-Xms200m -Xmx200m -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -Dconfig.file=/etc/gu/floodgate.conf'
+Environment='JAVA_OPTS=-Xms320m -Xmx320m -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -Dconfig.file=/etc/gu/floodgate.conf'
 WorkingDirectory=/home/content-api
 ExecStart=/home/content-api/floodgate/bin/content-api-floodgate
 


### PR DESCRIPTION
~~Concierge~~ Floodgate is frequently failing ELB health checks. And the frequency increases when re-indexing operations are performed. 

I suspect its due to the JVM being out of memory - in my experience a max heap size of 200MB is too small to run a Play application. 

For now, bump it to what it was prior to #64. I've also ssh'd onto the instance and confirmed from the current memory usage this increase is within the instance's capacity.

This PR is of particular importance as we will be making extensive use of this app as part of our work to improve reindexing. If the health check continues to fail after this change, then we'll have to consider moving to a `t3.micro` (maybe verifying that lack of memory is the issue as a preliminary task).
