### PR TITLE
chore: Add Dependabot config, running monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# See the documentation for all configuration options https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
Paired with @Fweddi .

This change sets up Dependabot in the repository to keep npm dependencies up to date once a month (it will run on the first of each month).

This change should be merged after https://github.com/guardian/floodgate/pull/88.