### PR TITLE
Set up for Wazuh and use encrypted AMI (because why not?)

### DIFF
--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -85,7 +85,7 @@ Resources:
                           - ec2:DescribeTags
                       Resource: "*"
             Roles:
-                - !Ref: RootRole
+                - !Ref RootRole
 
     Ec2DescribeAutoScalingGroupsPolicy:
         Type: AWS::IAM::Policy

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -73,6 +73,34 @@ Resources:
                       Resource:
                             - !Sub arn:aws:dynamodb:*:${AWS::AccountId}:table/floodgate-*-${Stage}
 
+    Ec2DescribeInstancesPolicy:
+        Type: AWS::IAM::Policy
+        Properties:
+            PolicyName: ec2-describe-instances
+            PolicyDocument:
+                Statement:
+                    - Effect: Allow
+                      Action:
+                          - ec2:DescribeInstances
+                          - ec2:DescribeTags
+                      Resource: "*"
+            Roles:
+                - !Ref: RootRole
+
+    Ec2DescribeAutoScalingGroupsPolicy:
+        Type: AWS::IAM::Policy
+        Properties:
+            PolicyName: ec2-describe-autoscaling-groups
+            PolicyDocument:
+                Statement:
+                    - Effect: Allow
+                      Action:
+                          - autoscaling:DescribeAutoScalingGroups
+                          - autoscaling:DescribeAutoScalingInstances
+                      Resource: "*"
+            Roles:
+                - !Ref RootRole
+
     InstanceProfile:
         Type: AWS::IAM::InstanceProfile
         Properties:
@@ -129,6 +157,7 @@ Resources:
             AssociatePublicIpAddress: true
             SecurityGroups:
                 - !Ref ApplicationSecurityGroup
+                - !Ref WazuhSecurityGroup
             InstanceType: t3.small
             IamInstanceProfile: !Ref InstanceProfile
             UserData:
@@ -177,6 +206,17 @@ Resources:
                 - { IpProtocol: tcp, FromPort: 9000, ToPort: 9000, SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup }
                 - { IpProtocol: tcp, FromPort: 9000, ToPort: 9000, CidrIp: 77.91.248.0/21 }
                 - { IpProtocol: tcp, FromPort: 22, ToPort: 22, CidrIp: 77.91.248.0/21 }
+
+    WazuhSecurityGroup:
+        Type: AWS::EC2::SecurityGroup
+        Properties:
+            GroupDescription: Allow outbound traffic from wazuh agent to manager
+            VpcId: !Ref VPC
+            SecurityGroupEgress:
+                - IpProtocol: tcp
+                FromPort: 1514
+                ToPort: 1515
+                CidrIp: 0.0.0.0/0
 
 Outputs:
     LoadBalancer:

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -214,9 +214,9 @@ Resources:
             VpcId: !Ref VPC
             SecurityGroupEgress:
                 - IpProtocol: tcp
-                FromPort: 1514
-                ToPort: 1515
-                CidrIp: 0.0.0.0/0
+                  FromPort: 1514
+                  ToPort: 1515
+                  CidrIp: 0.0.0.0/0
 
 Outputs:
     LoadBalancer:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -16,6 +16,7 @@ deployments:
       amiTags:
         Recipe: ubuntu-bionic-capi
         AmigoStage: PROD
+      amiEncrypted: true
       cloudFormationStackName: content-api-floodgate
       prependStackToCloudFormationStackName: false
       cloudFormationStackByTags: false


### PR DESCRIPTION
## What does this change?
Adds configuration to enable the Wazuh service. We should already be running on `ubuntu-bionic-capi` so the service should be available, just unable to communicate with the outside. We're also switching to the encrypted AMI version (assuming that we can for this project).

## How to test
When this new configuration is deployed, you can see the status of the Wazuh agent using the following command:
```
ssm cmd -c "service wazuh-agent status | grep Active && journalctl -u wazuh-agent | grep -E \"(Valid|error)\"" -t floodgate,content-api,PROD -p capi
```
which should give us a `Valid` response.

## How can we measure success?
Floodgate instance(s) will be visible to the security team. And Floodgate will continue to work, obvs!

## Have we considered potential risks?
We potentially can't reindex properly if Floodgate breaks.

## Images
N/A

## Accessibility
N/A
