### PR TITLE
Modernisation PR #2 - Java11 & JVM metrics

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 8
+          java-version: 11
           cache: sbt
 
       - name: Configure AWS Credentials

--- a/app/com/gu/floodgate/AppComponents.scala
+++ b/app/com/gu/floodgate/AppComponents.scala
@@ -18,7 +18,8 @@ import play.api.ApplicationLoader.Context
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.{BuiltInComponentsFromContext, NoHttpFiltersComponents}
 import play.api.routing.Router
-import controllers.{routes, Application, AssetsComponents, Healthcheck, Login}
+import controllers.{Application, AssetsComponents, Healthcheck, Login, routes}
+import io.prometheus.client.hotspot.DefaultExports
 import play.api.mvc.AnyContent
 import play.api.mvc.legacy.Controller
 import router.Routes
@@ -39,6 +40,9 @@ class AppComponents(context: Context)
   val configEnvironment = configuration.get[String]("env")
   val region = Region getRegion Regions.fromName(configuration.getOptional[String]("aws.region") getOrElse "eu-west-1")
   val clientConfiguration = new ClientConfiguration()
+
+  //set up the default metrics
+  DefaultExports.initialize()
 
   val dynamoDB: AmazonDynamoDBAsync = {
     val builder = AmazonDynamoDBAsyncClientBuilder.standard()

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ version := "1.0"
 resolvers += "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
 
 val awsClientVersion = "1.12.332"
+val prometheusVersion = "0.16.0"
 
 libraryDependencies ++= Seq(
   ws,
@@ -28,7 +29,9 @@ libraryDependencies ++= Seq(
   "org.scalatest"              %% "scalatest"            % "3.0.4" % "test",
   "org.typelevel"              %% "cats-core"            % "1.6.1",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
-
+  "io.prometheus" % "simpleclient" % prometheusVersion,
+  "io.prometheus" % "simpleclient_hotspot" % prometheusVersion,
+  "io.prometheus" % "simpleclient_common" % prometheusVersion,
   //required to make jackson work
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.4"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ version := "1.0"
 
 resolvers += "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
 
-val awsClientVersion = "1.12.332"
+val awsClientVersion = "1.12.351"
 val prometheusVersion = "0.16.0"
 
 libraryDependencies ++= Seq(
@@ -23,10 +23,10 @@ libraryDependencies ++= Seq(
   "com.typesafe.play"          %% "play-json-joda"       % "2.9.3",
   "com.typesafe.play"          %% "play-logback"         % "2.8.18",
   "com.typesafe.play"          %% "play-specs2"          % "2.8.18",
-  "com.gu"                     %% "play-googleauth"      % "0.7.7",
+  "com.gu"                     %% "play-googleauth"      % "0.7.9",
   "org.scanamo"                %% "scanamo"              % "1.0.0-M10",
   "org.scanamo"                %% "scanamo-joda"         % "1.0.0-M10",
-  "org.scalatest"              %% "scalatest"            % "3.0.4" % "test",
+  "org.scalatest"              %% "scalatest"            % "3.2.14" % "test",
   "org.typelevel"              %% "cats-core"            % "1.6.1",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.2",
   "io.prometheus" % "simpleclient" % prometheusVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := "content-api-floodgate"
 organization := "com.gu"
 description := "The Content API reindexing control panel"
 scalaVersion := "2.12.8"
-scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-target:jvm-1.8")
+scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked", "-release","11")
 version := "1.0"
 
 resolvers += "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"

--- a/cdk/lib/__snapshots__/floodgate.test.ts.snap
+++ b/cdk/lib/__snapshots__/floodgate.test.ts.snap
@@ -161,7 +161,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
         "ImageId": {
           "Ref": "AMIContentapifloodgate",
         },
-        "InstanceType": "t3.small",
+        "InstanceType": "t4g.small",
         "MetadataOptions": {
           "HttpTokens": "required",
         },

--- a/cdk/lib/__snapshots__/floodgate.test.ts.snap
+++ b/cdk/lib/__snapshots__/floodgate.test.ts.snap
@@ -161,7 +161,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
         "ImageId": {
           "Ref": "AMIContentapifloodgate",
         },
-        "InstanceType": "t4g.small",
+        "InstanceType": "t3.small",
         "MetadataOptions": {
           "HttpTokens": "required",
         },

--- a/cdk/lib/__snapshots__/floodgate.test.ts.snap
+++ b/cdk/lib/__snapshots__/floodgate.test.ts.snap
@@ -5,6 +5,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuParameter",
+      "GuParameter",
       "GuPolicy",
       "GuEc2App",
       "GuCertificate",
@@ -53,6 +54,11 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
     "LoggingStreamName": {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "PromRemoteWrite": {
+      "Default": "/account/content-api-common/metrics/prometheus_remote_write_url",
+      "Description": "SSM path pointing to the parameter which gives an Amazon Managed Prometheus endpoint to push metrics to",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "SsmParameterValueaccountservicescapigutoolsTESThostedzoneidC96584B6F00A464EAD1953AFF4B05118Parameter": {
@@ -212,7 +218,55 @@ chgrp -R content-api /home/content-api /etc/gu
 
 systemctl start content-api-floodgate
 
-ln -s /usr/share/content-api-floodgate floodgate",
+ln -s /usr/share/content-api-floodgate floodgate
+
+export HOSTNAME=$(hostname)
+cat > /etc/gu/otel.yaml << EOF
+extensions:
+  sigv4auth:
+    service: "aps"  #APS refers to "Amazon Prometheus Service" aka Amazon Managed Prometheus aka AMP
+    region: "",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ""
+
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'floodgate'
+          scrape_interval: 120s
+          static_configs:
+            # metrics endpoint for your app
+            - targets: [ '0.0.0.0:9000' ]
+              labels:
+                instance: \${HOSTNAME}
+                stack: content-api-floodgate
+                stage: TEST
+processors:
+  batch/metrics:
+    timeout: 120s
+
+exporters:
+  prometheusremotewrite:
+    endpoint: "",
+                {
+                  "Ref": "PromRemoteWrite",
+                },
+                ""
+    auth:
+      authenticator: sigv4auth
+
+service:
+  extensions: [sigv4auth]
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch/metrics]
+      exporters: [prometheusremotewrite]
+EOF
+/opt/aws/aws-otel-collector/bin/aws-otel-collector-ctl -c /etc/gu/otel.yaml -a start",
               ],
             ],
           },
@@ -379,6 +433,11 @@ ln -s /usr/share/content-api-floodgate floodgate",
                 "autoscaling:DescribeAutoScalingGroups",
                 "autoscaling:DescribeAutoScalingInstances",
               ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": "aps:RemoteWrite",
               "Effect": "Allow",
               "Resource": "*",
             },

--- a/cdk/lib/floodgate.ts
+++ b/cdk/lib/floodgate.ts
@@ -11,7 +11,7 @@ import {GuPolicy} from "@guardian/cdk/lib/constructs/iam";
 import {Effect, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Datastore} from "./datastore";
 
-const useArm = true;
+const useArm = false;
 
 export class Floodgate extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {

--- a/cdk/lib/floodgate.ts
+++ b/cdk/lib/floodgate.ts
@@ -11,6 +11,8 @@ import {GuPolicy} from "@guardian/cdk/lib/constructs/iam";
 import {Effect, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Datastore} from "./datastore";
 
+const useArm = true;
+
 export class Floodgate extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {
     super(scope, id, props);
@@ -104,7 +106,7 @@ export class Floodgate extends GuStack {
         domainName: this.stage==="CODE" ? "floodgate.capi.code.dev-gutools.co.uk" : "floodgate.capi.gutools.co.uk",
         hostedZoneId: dnsZone,
       },
-      instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
+      instanceType: useArm ? InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL) : InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
       monitoringConfiguration: {
         snsTopicName: `floogate-monitoring-${this.stage}`,
         http5xxAlarm: {

--- a/conf/routes
+++ b/conf/routes
@@ -4,6 +4,7 @@
 
 # Handled by client side code
 GET         /                                                             controllers.Application.index
+GET        /metrics                                                         controllers.Application.metrics
 
 # Healthcheck
 GET        /healthcheck                                                   controllers.Healthcheck.healthcheck

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -20,6 +20,6 @@ deployments:
       amiParameter: AMIContentapifloodgate
       amiEncrypted: true
       amiTags:
-        Recipe: ubuntu-focal-capi-arm-jdk11
+        Recipe: ubuntu-focal-capi-x86-jdk11
         AmigoStage: PROD
         BuiltBy: amigo

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -20,6 +20,6 @@ deployments:
       amiParameter: AMIContentapifloodgate
       amiEncrypted: true
       amiTags:
-        Recipe: ubuntu-focal-capi-x86-jdk11
+        Recipe: ubuntu-focal-capi-arm-jdk11
         AmigoStage: PROD
         BuiltBy: amigo

--- a/test/com/gu/floodgate/FloodgateIntegrationSpec.scala
+++ b/test/com/gu/floodgate/FloodgateIntegrationSpec.scala
@@ -1,23 +1,19 @@
 package controllers
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import com.gu.floodgate.AppLoader
 import com.gu.floodgate.reindex.{Completed, InProgress, Progress}
-import org.scalatest.{FlatSpec, Matchers}
 import play.api.mvc.Call
 import play.api.test.{FakeRequest, WithApplicationLoader}
 import play.api.test.Helpers._
-import play.api.Configuration
-import play.api.Environment
-import play.api.libs.ws.ahc.AhcWSClient
 import com.gu.floodgate.Formats._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * These tests are provided as a way of demonstrating how we expect the reindex endpoints on a particular content
   * source to behave in order to have integration with Floodgate.
   */
-class FloodgateIntegrationSpec extends FlatSpec with Matchers {
+class FloodgateIntegrationSpec extends AnyFlatSpec with Matchers {
 
   val reindexRoute = "/reindex"
   val initiateReindexRequest = new Call("POST", reindexRoute)

--- a/test/com/gu/floodgate/HealthcheckSpec.scala
+++ b/test/com/gu/floodgate/HealthcheckSpec.scala
@@ -1,11 +1,12 @@
 package controllers
 
 import com.gu.floodgate.AppLoader
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test.{FakeRequest, WithApplicationLoader}
 import play.api.test.Helpers._
 
-class HealthcheckSpec extends FlatSpec with Matchers {
+class HealthcheckSpec extends AnyFlatSpec with Matchers {
 
   val healthcheck = new Healthcheck
   val appLoader = new AppLoader

--- a/test/com/gu/floodgate/contentsource/ContentSourceReindexUrlTest.scala
+++ b/test/com/gu/floodgate/contentsource/ContentSourceReindexUrlTest.scala
@@ -2,9 +2,10 @@ package com.gu.floodgate.contentsource
 
 import com.gu.floodgate.reindex.DateParameters
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ContentSourceReindexUrlTest extends FlatSpec with Matchers {
+class ContentSourceReindexUrlTest extends AnyFlatSpec with Matchers {
 
   val contentSourceWithApiKeyAuth =
     ContentSource(

--- a/test/com/gu/floodgate/reindex/DateParametersTest.scala
+++ b/test/com/gu/floodgate/reindex/DateParametersTest.scala
@@ -2,10 +2,11 @@ package com.gu.floodgate.reindex
 
 import com.gu.floodgate.CustomError
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import cats.syntax.either._
 
-class DateParametersTest extends FlatSpec with Matchers {
+class DateParametersTest extends AnyFlatSpec with Matchers {
 
   behavior of "DateParameters"
 


### PR DESCRIPTION
Follow-on from #106 

## What does this change?

- Tells `scalac` to target JVM-11 runtime environment
- Adds Prometheus for JVM metrics and sets up egest to AMP
- Tested Graviton (ARM) compatibility

## How to test

Just deploy it and see if it runs. Check the logs under "Floodgate" in Central ELK / Content Platforms

## How can we measure success?

It should be neat, tidy and monitorable :)

## Have we considered potential risks?

n/a
