### PR TITLE
Update access methodology

### DIFF
--- a/cdk/lib/__snapshots__/floodgate.test.ts.snap
+++ b/cdk/lib/__snapshots__/floodgate.test.ts.snap
@@ -23,7 +23,6 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
-      "GuSecurityGroup",
       "GuAlb5xxPercentageAlarm",
       "GuUnhealthyInstancesAlarm",
     ],
@@ -481,27 +480,6 @@ ln -s /usr/share/content-api-floodgate floodgate",
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "GuHttpsEgressSecurityGroupContentapifloodgatefromFloodgateRestrictedIngressSecurityGroupContentapifloodgate923A4F0790008DBFFA25": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupContentapifloodgateE68A17B8",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "RestrictedIngressSecurityGroupContentapifloodgate7B667D75",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
     "GuLogShippingPolicy981BFE5A": {
       "Properties": {
         "PolicyDocument": {
@@ -781,12 +759,6 @@ ln -s /usr/share/content-api-floodgate floodgate",
               "GroupId",
             ],
           },
-          {
-            "Fn::GetAtt": [
-              "RestrictedIngressSecurityGroupContentapifloodgate7B667D75",
-              "GroupId",
-            ],
-          },
         ],
         "Subnets": {
           "Ref": "subnets",
@@ -820,6 +792,15 @@ ln -s /usr/share/content-api-floodgate floodgate",
     "LoadBalancerContentapifloodgateSecurityGroup6BAE37E7": {
       "Properties": {
         "GroupDescription": "Automatically created Security Group for ELB FloodgateLoadBalancerContentapifloodgate81852B8B",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
         "Tags": [
           {
             "Key": "App",
@@ -927,67 +908,6 @@ ln -s /usr/share/content-api-floodgate floodgate",
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "RestrictedIngressSecurityGroupContentapifloodgate7B667D75": {
-      "Properties": {
-        "GroupDescription": "Allow restricted ingress from CIDR ranges",
-        "SecurityGroupIngress": [
-          {
-            "CidrIp": "77.91.248.0/21",
-            "Description": "Allow access on port 443 from 77.91.248.0/21",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "content-api-floodgate",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/floodgate",
-          },
-          {
-            "Key": "Stack",
-            "Value": "content-api-floodgate",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VpcId": {
-          "Ref": "SsmParameterValueaccountvpcTESTgenericidC96584B6F00A464EAD1953AFF4B05118Parameter",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "RestrictedIngressSecurityGroupContentapifloodgatetoFloodgateGuHttpsEgressSecurityGroupContentapifloodgateFC06BEAD9000BBA59A73": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupContentapifloodgateE68A17B8",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "RestrictedIngressSecurityGroupContentapifloodgate7B667D75",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "RunningJob4D26EAC6": {
       "DeletionPolicy": "Retain",

--- a/cdk/lib/floodgate.ts
+++ b/cdk/lib/floodgate.ts
@@ -42,8 +42,7 @@ export class Floodgate extends GuStack {
 
     new GuEc2App(this, {
       access: {
-        scope: AccessScope.RESTRICTED,
-        cidrRanges: [Peer.ipv4("77.91.248.0/21")],
+        scope: AccessScope.PUBLIC,
       },
       app: "content-api-floodgate",
       applicationLogging: {


### PR DESCRIPTION
## What does this change?

Allow public access. WAF is manually configured in front of the ALB and openID applied on the ALB, in addition to the existing auth in the app

## How to test

You can log in

## How can we measure success?

You can log in
