### PR TITLE
Fix hanging reindexes

### DIFF
--- a/cdk/lib/__snapshots__/floodgate.test.ts.snap
+++ b/cdk/lib/__snapshots__/floodgate.test.ts.snap
@@ -25,6 +25,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
       "GuHttpsApplicationListener",
       "GuAlb5xxPercentageAlarm",
       "GuUnhealthyInstancesAlarm",
+      "GuSecurityGroup",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -168,6 +169,12 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
           {
             "Fn::GetAtt": [
               "WazuhSecurityGroup",
+              "GroupId",
+            ],
+          },
+          {
+            "Fn::GetAtt": [
+              "InstanceOutboundSGContentapifloodgate22B30938",
               "GroupId",
             ],
           },
@@ -627,6 +634,44 @@ ln -s /usr/share/content-api-floodgate floodgate",
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "InstanceOutboundSGContentapifloodgate22B30938": {
+      "Properties": {
+        "GroupDescription": "Floodgate/InstanceOutboundSGContentapifloodgate",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "content-api-floodgate",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/floodgate",
+          },
+          {
+            "Key": "Stack",
+            "Value": "content-api-floodgate",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "SsmParameterValueaccountvpcTESTgenericidC96584B6F00A464EAD1953AFF4B05118Parameter",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
     },
     "InstanceRoleContentapifloodgate4A6AA3CB": {
       "Properties": {

--- a/cdk/lib/__snapshots__/floodgate.test.ts.snap
+++ b/cdk/lib/__snapshots__/floodgate.test.ts.snap
@@ -640,9 +640,11 @@ ln -s /usr/share/content-api-floodgate floodgate",
         "GroupDescription": "Floodgate/InstanceOutboundSGContentapifloodgate",
         "SecurityGroupEgress": [
           {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
+            "CidrIp": "10.248.0.0/16",
+            "Description": "Outgoing to port 8080 on internal infrastructure",
+            "FromPort": 8080,
+            "IpProtocol": "tcp",
+            "ToPort": 8080,
           },
         ],
         "Tags": [

--- a/cdk/lib/floodgate.ts
+++ b/cdk/lib/floodgate.ts
@@ -110,11 +110,13 @@ export class Floodgate extends GuStack {
 
     app.autoScalingGroup.addSecurityGroup(new GuSecurityGroup(this, "InstanceOutboundSG", {
       app: "content-api-floodgate",
+      allowAllOutbound: false,
+      allowAllIpv6Outbound: false,
       egresses: [
         {
           range: Peer.ipv4("10.248.0.0/16"),
-          port: Port.tcp(80),
-          description: "Outgoing to port 80 on internal infrastructure"
+          port: Port.tcp(8080),
+          description: "Outgoing to port 8080 on internal infrastructure"
         }
       ],
       vpc,

--- a/cdk/lib/floodgate.ts
+++ b/cdk/lib/floodgate.ts
@@ -4,9 +4,9 @@ import type {App} from "aws-cdk-lib";
 import {aws_ssm, Stack} from "aws-cdk-lib";
 import {GuEc2App} from "@guardian/cdk";
 import {AccessScope} from "@guardian/cdk/lib/constants";
-import {InstanceClass, InstanceSize, InstanceType, Peer, Vpc} from "aws-cdk-lib/aws-ec2";
+import {InstanceClass, InstanceSize, InstanceType, Peer, Port, Vpc} from "aws-cdk-lib/aws-ec2";
 import fs from "fs";
-import {GuVpc} from "@guardian/cdk/lib/constructs/ec2";
+import {GuSecurityGroup, GuVpc} from "@guardian/cdk/lib/constructs/ec2";
 import {GuPolicy} from "@guardian/cdk/lib/constructs/iam";
 import {Effect, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Datastore} from "./datastore";
@@ -40,7 +40,7 @@ export class Floodgate extends GuStack {
         .replace(/\$\{AWS::Region}/g, Stack.of(this).region)
         .replace(/\$\{BuiltVersion}/g, "1.0");
 
-    new GuEc2App(this, {
+    const app = new GuEc2App(this, {
       access: {
         scope: AccessScope.PUBLIC,
       },
@@ -106,7 +106,19 @@ export class Floodgate extends GuStack {
       },
       userData: userData,
       vpc,
-    })
+    });
+
+    app.autoScalingGroup.addSecurityGroup(new GuSecurityGroup(this, "InstanceOutboundSG", {
+      app: "content-api-floodgate",
+      egresses: [
+        {
+          range: Peer.ipv4("10.248.0.0/16"),
+          port: Port.tcp(80),
+          description: "Outgoing to port 80 on internal infrastructure"
+        }
+      ],
+      vpc,
+    }))
   }
 
   getAccountPath(elementName: string) {


### PR DESCRIPTION
## What does this change?

Adjusts outgoing instance SGs to not block access to the Flex re-index endpoints

## How to test

Tested on CODE. Attempt a flexible content re-index, looking at the logs. Without this, you get a timeout error after 2mins. With it, the re-index proceeds
