### PR TITLE
Switch to using Pekko instead of Akka internally

### DIFF
--- a/app/com/gu/floodgate/Application.scala
+++ b/app/com/gu/floodgate/Application.scala
@@ -34,6 +34,9 @@ class Application(
     TextFormat.write004(writer, CollectorRegistry.defaultRegistry.metricFamilySamples())
     Result(
       ResponseHeader(200),
+     //in order to force the MIME type here, we need to use Play's `HttpEntity.Strict` which requires converting any response body into
+     //an akka.util.ByteString.  This should count as "fair use" and allowed regardless of Akka version becase its only purpose is to feed Play
+     //and it is therefore covered under Play's license terms
       HttpEntity.Strict(akka.util.ByteString(writer.toString), Some("text/plain; version=0.0.4; charset=UTF-8")))
   }
 

--- a/app/com/gu/floodgate/Application.scala
+++ b/app/com/gu/floodgate/Application.scala
@@ -34,7 +34,7 @@ class Application(
     TextFormat.write004(writer, CollectorRegistry.defaultRegistry.metricFamilySamples())
     Result(
       ResponseHeader(200),
-      HttpEntity.Strict(ByteString(writer.toString), Some("text/plain; version=0.0.4; charset=UTF-8")))
+      HttpEntity.Strict(akka.util.ByteString(writer.toString), Some("text/plain; version=0.0.4; charset=UTF-8")))
   }
 
   /*

--- a/app/com/gu/floodgate/Application.scala
+++ b/app/com/gu/floodgate/Application.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import com.gu.floodgate.reindex.{Completed, InProgress, Progress}
 import com.typesafe.scalalogging.StrictLogging
 import play.api.Configuration

--- a/app/com/gu/floodgate/contentsource/ContentSourceApi.scala
+++ b/app/com/gu/floodgate/contentsource/ContentSourceApi.scala
@@ -2,9 +2,9 @@ package com.gu.floodgate.contentsource
 
 import java.util.UUID
 
-import akka.actor.ActorRef
-import akka.pattern.ask
-import akka.util.Timeout
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.util.Timeout
 import com.gu.floodgate.{BulkReindexInProcess, ErrorResponse}
 import com.gu.floodgate.Formats._
 import com.gu.floodgate.jobhistory.{JobHistoriesResponse, JobHistoryService}

--- a/app/com/gu/floodgate/contentsource/ContentSourceTable.scala
+++ b/app/com/gu/floodgate/contentsource/ContentSourceTable.scala
@@ -1,10 +1,6 @@
 package com.gu.floodgate.contentsource
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
-import com.amazonaws.services.dynamodbv2.model.{AttributeValue, AttributeValueUpdate}
 import com.gu.floodgate.DynamoDBTable
-
-import scala.collection.JavaConverters._
 import org.scanamo.{DynamoFormat, Scanamo, ScanamoAsync}
 
 class ContentSourceTable(

--- a/app/com/gu/floodgate/reindex/BulkJobActor.scala
+++ b/app/com/gu/floodgate/reindex/BulkJobActor.scala
@@ -1,7 +1,7 @@
 package com.gu.floodgate.reindex
 
-import akka.actor.{Actor, ActorLogging, Props}
-import akka.pattern.pipe
+import org.apache.pekko.actor.{Actor, ActorLogging, Props}
+import org.apache.pekko.pattern.pipe
 import com.gu.floodgate.{CustomError, RunningJobNotFound}
 import com.gu.floodgate.contentsource.{ContentSource, ContentSourceSettings}
 import com.gu.floodgate.jobhistory.{JobHistory, JobHistoryService}

--- a/app/com/gu/floodgate/reindex/ProgressTracker.scala
+++ b/app/com/gu/floodgate/reindex/ProgressTracker.scala
@@ -1,6 +1,6 @@
 package com.gu.floodgate.reindex
 
-import akka.actor.{Actor, ActorLogging, Cancellable, Props}
+import org.apache.pekko.actor.{Actor, ActorLogging, Cancellable, Props}
 import com.gu.floodgate.contentsource.ContentSource
 import com.gu.floodgate.jobhistory.{JobHistory, JobHistoryService}
 import com.gu.floodgate.reindex.ProgressTracker.{Cancel, TrackProgress, UpdateProgress}

--- a/app/com/gu/floodgate/reindex/ProgressTrackerController.scala
+++ b/app/com/gu/floodgate/reindex/ProgressTrackerController.scala
@@ -1,6 +1,6 @@
 package com.gu.floodgate.reindex
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props}
 import com.gu.floodgate.contentsource.ContentSource
 import com.gu.floodgate.jobhistory.JobHistoryService
 import com.gu.floodgate.reindex.ProgressTracker.{Cancel, TrackProgress}

--- a/app/com/gu/floodgate/reindex/ReindexService.scala
+++ b/app/com/gu/floodgate/reindex/ReindexService.scala
@@ -1,6 +1,6 @@
 package com.gu.floodgate.reindex
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import com.gu.floodgate._
 import com.gu.floodgate.contentsource.{ContentSource, ContentSourceService}
 import com.gu.floodgate.reindex.ProgressTrackerController.{LaunchTracker, RemoveTracker}

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ resolvers += "Sonatype releases" at "https://oss.sonatype.org/content/repositori
 
 val awsClientVersion = "1.12.351"
 val prometheusVersion = "0.16.0"
+val PekkoVersion = "1.0.1"
 
 libraryDependencies ++= Seq(
   ws,
@@ -32,6 +33,10 @@ libraryDependencies ++= Seq(
   "io.prometheus" % "simpleclient" % prometheusVersion,
   "io.prometheus" % "simpleclient_hotspot" % prometheusVersion,
   "io.prometheus" % "simpleclient_common" % prometheusVersion,
+
+  "org.apache.pekko" %% "pekko-actor" % PekkoVersion,
+  "org.apache.pekko" %% "pekko-testkit" % PekkoVersion % Test,
+
   //required to make jackson work
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.2"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.3
+sbt.version=1.9.2


### PR DESCRIPTION
## What does this change?

Switches our internal use of Akka (actors, streams etc.) to use Apache Pekko instead.

## How to test

Run it up and do some re-indexes.  It should still work....

## How can we measure success?

No license/vuln issues when Akka 2.6 goes out of support
