### PR TITLE
Fix snyk high vuln in jetty-http package.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,8 @@ ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8
 dependencyOverrides ++=  Seq(
   "com.google.oauth-client" % "google-oauth-client" % "1.33.3",
   "org.seleniumhq.selenium" % "htmlunit-driver" % "4.8.1",
-  "com.squareup.okhttp3" % "okhttp" % "4.10.0"
+  "com.squareup.okhttp3" % "okhttp" % "4.10.0",
+  "org.eclipse.jetty" % "jetty-http" % "9.4.53.v20231009"
   )
 
 routesGenerator := InjectedRoutesGenerator

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,10 @@ libraryDependencies ++= Seq(
   "org.apache.pekko" %% "pekko-testkit" % PekkoVersion % Test,
 
   //required to make jackson work
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.2"
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.2",
+
+  //required to pass the failing test after jetty-http is placed in dependency override. jetty-http is placed due to fix snyk high vuln.
+  "ch.qos.logback" % "logback-classic" % "1.4.7"
 )
 
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
@@ -47,7 +50,7 @@ dependencyOverrides ++=  Seq(
   "com.google.oauth-client" % "google-oauth-client" % "1.33.3",
   "org.seleniumhq.selenium" % "htmlunit-driver" % "4.8.1",
   "com.squareup.okhttp3" % "okhttp" % "4.10.0",
-  "org.eclipse.jetty" % "jetty-http" % "9.4.53.v20231009"
+  "org.eclipse.jetty" % "jetty-http" % "11.0.16"
   )
 
 routesGenerator := InjectedRoutesGenerator


### PR DESCRIPTION
## What does this change?

Snyk raised 1 high vuln in jetty-http package in floodgate.

Recommended versions to upgrade is to @9.4.53.v20231009, @10.0.16, @11.0.16

It is upgraded to 11.0.16 but tests were failing with exception 
<img width="1657" alt="image" src="https://github.com/guardian/floodgate/assets/17780995/95552991-55fd-4c06-866d-21a98c9e25f6">

so added `logback classic` library to fix. 
referred doc for which library to in case of NOP slf4j library is there - https://www.slf4j.org/codes.html#noProviders


## How to test

`sbt test`
and run locally as given in readme file just to make sure floodgate is running.
and than run `snyk test --org=guardian-capi --all-projects` 

## How can we measure success?

Tests should pass.
Floodgate should overcome by high vuln in snyk.

Note-Hope, addition of `logback-classic` should be able to do what is intended. 
Will wait for team's review as well.

