### PR TITLE
Start backing up DynamoDB tables using AWS Backup

### DIFF
--- a/cdk/lib/__snapshots__/floodgate.test.ts.snap
+++ b/cdk/lib/__snapshots__/floodgate.test.ts.snap
@@ -215,6 +215,10 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
         "TableName": "floodgate-content-source-TEST",
         "Tags": [
           {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -707,6 +711,10 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
         "TableName": "floodgate-job-history-TEST",
         "Tags": [
           {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -989,6 +997,10 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
         },
         "TableName": "floodgate-running-job-TEST",
         "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/cdk/lib/datastore.ts
+++ b/cdk/lib/datastore.ts
@@ -1,6 +1,8 @@
+import type {GuStack} from "@guardian/cdk/lib/constructs/core";
+import {Tags} from "aws-cdk-lib";
+import type { ITable} from "aws-cdk-lib/aws-dynamodb";
+import {AttributeType, BillingMode, Table, TableEncryption} from "aws-cdk-lib/aws-dynamodb";
 import {Construct} from "constructs";
-import {GuStack} from "@guardian/cdk/lib/constructs/core";
-import {AttributeType, BillingMode, ITable, Table, TableEncryption} from "aws-cdk-lib/aws-dynamodb";
 
 export class Datastore extends Construct {
     contentSourceTable: ITable;
@@ -51,5 +53,11 @@ export class Datastore extends Construct {
             billingMode: BillingMode.PAY_PER_REQUEST,
             tableName: `floodgate-running-job-${scope.stage}`
         });
+
+        // Enable automated backups for all DynamoDB tables via https://github.com/guardian/aws-backup
+        [this.contentSourceTable, this.jobHistoryTable, this.runningJobTable].map((table) => {
+            Tags.of(table).add("devx-backup-enabled", "true");
+        })
+
     }
 }


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up `floodgate`'s DynamoDB tables using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit).

## How to test

Backups are created every night; we should be able to deploy this change to `CODE` and confirm that the tables are backed up tomorrow morning.

## How can we measure success?

This will help us to recover more quickly if these tables are ever deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details.