### PR TITLE
Persist and surface reindexing document counts

### DIFF
--- a/app/com/gu/floodgate/jobhistory/JobHistory.scala
+++ b/app/com/gu/floodgate/jobhistory/JobHistory.scala
@@ -10,7 +10,9 @@ case class JobHistory(
     status: ReindexStatus,
     environment: String,
     rangeFrom: Option[DateTime],
-    rangeTo: Option[DateTime]
+    rangeTo: Option[DateTime],
+    documentsExpected: Option[Int],
+    documentsIndexed: Option[Int]
 )
 
 case class JobHistoriesResponse(jobHistories: Seq[JobHistory])

--- a/app/com/gu/floodgate/reindex/BulkJobActor.scala
+++ b/app/com/gu/floodgate/reindex/BulkJobActor.scala
@@ -44,7 +44,9 @@ object BulkJobActor {
       env: String,
       startTime: DateTime,
       finishTime: DateTime,
-      status: ReindexStatus
+      status: ReindexStatus,
+      documentsIndexed: Option[Int],
+      documentsExpected: Option[Int]
   )
   object CompletedJobInfo {
     def apply(source: ContentSource, history: JobHistory): CompletedJobInfo = {
@@ -54,7 +56,9 @@ object BulkJobActor {
         source.environment,
         history.startTime,
         history.finishTime,
-        history.status
+        history.status,
+        history.documentsExpected,
+        history.documentsIndexed
       )
     }
   }

--- a/app/com/gu/floodgate/reindex/ProgressTracker.scala
+++ b/app/com/gu/floodgate/reindex/ProgressTracker.scala
@@ -185,7 +185,9 @@ class ProgressTracker(ws: WSClient, runningJobService: RunningJobService, jobHis
       status,
       runningJob.contentSourceEnvironment,
       runningJob.rangeFrom,
-      runningJob.rangeTo
+      runningJob.rangeTo,
+      Some(runningJob.documentsExpected),
+      Some(runningJob.documentsIndexed)
     )
     runningJobService.removeRunningJob(runningJob.contentSourceId, runningJob.contentSourceEnvironment)
     jobHistoryService.createJobHistory(jobHistory)

--- a/public/components/jobHistory.react.js
+++ b/public/components/jobHistory.react.js
@@ -18,6 +18,7 @@ export default class JobHistory extends React.Component {
                     <td><JobHistoryDateRange rangeFrom={jobHistory.rangeFrom} rangeTo={jobHistory.rangeTo} /></td>
                     <td>{ new Date(jobHistory.startTime).toUTCString() }</td>
                     <td>{ new Date(jobHistory.finishTime).toUTCString() }</td>
+                    <td>{jobHistory.documentsIndexed} / {jobHistory.documentsExpected}</td>
                 </tr>
             );
         });
@@ -34,6 +35,7 @@ export default class JobHistory extends React.Component {
                                 <th>Date Range</th>
                                 <th>Start Time</th>
                                 <th>Finish Time</th>
+                                <th>Documents Indexed</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Reindex history captures the expected and indexed document counts from running jobs and persists them.

It's not obvious to the casual reindex users that this information is available.
It's visual in the Flexible Content reindex API but no in our UI.
Surface these counts as part of our reindex early / reindex often ethos.

Also surfaces that some content items are not Streamable and the indexed count does somethings fall short of expected count.

<img width="996" alt="Screenshot 2023-11-21 at 12 11 50" src="https://github.com/guardian/floodgate/assets/150238/3d2d73c0-6345-40f1-a3e7-ab307fc14109">



## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Document counts start to persist. This visibility gives us insight into which content sources are sending meaningful amounts of count.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
