### PR TITLE
Upgrade Play and Logback for Snyk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 public/build
 .ensime*
 dist/
+junit/

--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,8 @@ libraryDependencies ++= Seq(
   ws,
   "com.amazonaws"              % "aws-java-sdk-kinesis"  % awsClientVersion,
   "com.amazonaws"              % "aws-java-sdk-dynamodb" % awsClientVersion,
-  "com.typesafe.scala-logging" %% "scala-logging"        % "3.9.5",
-  "com.typesafe.play"          %% "play-json"            % "2.9.4",
-  "com.typesafe.play"          %% "play-json-joda"       % "2.9.4",
-  "com.typesafe.play"          %% "play-logback"         % "2.8.18",
-  "com.typesafe.play"          %% "play-specs2"          % "2.8.19",
+  "com.typesafe.play"          %% "play-json-joda"       % "2.10.3",
+  "com.typesafe.play"          %% "play-specs2"          % "2.8.21",
   "com.gu.play-googleauth"     %% "play-v27"             % "1.0.3",
   "org.scanamo"                %% "scanamo"              % "1.0.0-M11",
   "org.scanamo"                %% "scanamo-joda"         % "1.0.0-M11",
@@ -64,6 +61,3 @@ Debian / daemonGroup := "content-api"
 Debian / serviceAutostart := false  //we don't want to start immediately after installation, we want to customise the setup first
 
 Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u", sys.env.getOrElse("SBT_JUNIT_OUTPUT", "junit"))
-
-
-

--- a/build.sbt
+++ b/build.sbt
@@ -36,9 +36,6 @@ libraryDependencies ++= Seq(
 
   //required to make jackson work
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.2",
-
-  //required to pass the failing test after jetty-http is placed in dependency override. jetty-http is placed due to fix snyk high vuln.
-  "ch.qos.logback" % "logback-classic" % "1.4.7"
 )
 
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
@@ -47,8 +44,9 @@ dependencyOverrides ++=  Seq(
   "com.google.oauth-client" % "google-oauth-client" % "1.33.3",
   "org.seleniumhq.selenium" % "htmlunit-driver" % "4.8.1",
   "com.squareup.okhttp3" % "okhttp" % "4.10.0",
-  "org.eclipse.jetty" % "jetty-http" % "11.0.16"
-  )
+  "org.eclipse.jetty" % "jetty-http" % "11.0.18",
+  "ch.qos.logback" % "logback-classic" % "1.4.12"
+)
 
 routesGenerator := InjectedRoutesGenerator
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"            % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"            % "2.8.21")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"          % "2.0.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-twirl"             % "1.5.1")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")


### PR DESCRIPTION
This change upgrades the version of Play and Logback to fix a security issue reported by Snyk:

https://app.snyk.io/org/guardian-capi/project/ad3b68a3-bbb7-4d10-86b1-88a89bc39409#issue-SNYK-JAVA-CHQOSLOGBACK-6094942

I have also removed some explicit dependencies on individual built-in Play components (for example `play-json`). It isn't neccessary to reference them explicitly in the dependencies because we are bringing in Play via the plugin, and this allows us to keep the versions consistent.

I have deployed this on PROD, and have done a small reindex, and checked that we are still logging.

<img width="1205" alt="image" src="https://github.com/guardian/floodgate/assets/2242307/9652458f-7356-4e66-806a-921ca05d94cc">
