### PR TITLE
Update to actions-riff-raff@v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
-          cache: 'yarn'
+          cache: "yarn"
           cache-dependency-path: cdk/yarn.lock
 
       - run: yarn install --frozen-lockfile
@@ -73,6 +73,6 @@ jobs:
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()  #runs even if there is a test failure
+        if: always() #runs even if there is a test failure
         with:
           files: junit-tests/*.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,24 +46,19 @@ jobs:
           java-version: 11
           cache: sbt
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          role-session-name: content-api-sanity-tests-build
-
       - name: Build and test
         env:
           SBT_JUNIT_OUTPUT: ./junit-tests
         run: |
           sbt 'test;debian:packageBin'
 
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
           configPath: riff-raff.yaml
           projectName: Content Platforms::floodgate
           buildNumberOffset: 397
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           contentDirectories: |
             cloudformation:
               - cdk/cdk.out/Floodgate-CODE.template.json


### PR DESCRIPTION
Saw a recent email from DevX about upgrading, figured I’d do it quickly. Version 4 means we can get rid of the AWS credentials step and leaves us less vulnerable to credentials access by malicious dependencies

See [the release notes for version 4](https://github.com/guardian/actions-riff-raff/releases/tag/v4) and [those for version 3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0) (the latter necessary because we’re coming from version 2.)

(Have also committed auto-formatting done by my editor, hope that’s ok)