### PR TITLE
Bump snyk workflow to pull Java 11 for updated Play compatibility

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,6 +13,6 @@ jobs:
       DEBUG: true
       ORG: guardian-capi
       SKIP_NODE: false
-      JAVA_VERSION: 8
+      JAVA_VERSION: 11
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

After the merge of #139 Snyk did not update. Turned out that the Snyk workflow failed, because the workflow pulled in Java 8 which is not longer compatible with Play, causing an exception in SBT.

This PR updates the workflow to get Java 11 instead.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
