### PR TITLE
Permit adding, removing and editing headers for floodgate content sources' reindex requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ public/build
 .ensime*
 dist/
 junit/
+.metals

--- a/app/com/gu/floodgate/contentsource/ContentSource.scala
+++ b/app/com/gu/floodgate/contentsource/ContentSource.scala
@@ -15,7 +15,8 @@ case class ContentSourceWithoutId(
     reindexEndpoint: String,
     environment: String,
     authType: String,
-    contentSourceSettings: ContentSourceSettings
+    contentSourceSettings: ContentSourceSettings,
+    headers: Option[Map[String, String]]
 )
 
 case class ContentSourcesResponse(contentSources: Seq[ContentSource])
@@ -56,7 +57,8 @@ case class ContentSource(
     reindexEndpoint: String,
     environment: String,
     authType: String,
-    contentSourceSettings: ContentSourceSettings
+    contentSourceSettings: ContentSourceSettings,
+    headers: Option[Map[String, String]]
 ) {
 
   def uniqueId: String = s"$id-$environment"
@@ -84,7 +86,8 @@ case class ContentWithoutIdAndEnvironment(
     description: String,
     reindexEndpoint: String,
     authType: String,
-    contentSourceSettings: ContentSourceSettings
+    contentSourceSettings: ContentSourceSettings,
+    headers: Option[Map[String, String]]
 )
 
 object ContentSource {
@@ -102,7 +105,8 @@ object ContentSource {
       contentSourceWithoutId.reindexEndpoint,
       contentSourceWithoutId.environment,
       contentSourceWithoutId.authType,
-      contentSourceWithoutId.contentSourceSettings
+      contentSourceWithoutId.contentSourceSettings,
+      contentSourceWithoutId.headers
     )
   }
 
@@ -114,7 +118,8 @@ object ContentSource {
       contentSource.reindexEndpoint,
       environment,
       contentSource.authType,
-      contentSource.contentSourceSettings
+      contentSource.contentSourceSettings,
+      contentSource.headers
     )
   }
 }

--- a/app/com/gu/floodgate/reindex/ReindexService.scala
+++ b/app/com/gu/floodgate/reindex/ReindexService.scala
@@ -62,8 +62,13 @@ class ReindexService(
       dateParameters: DateParameters
   )(implicit ec: ExecutionContext): Future[Either[CustomError, RunningJob]] = {
     val reindexUrl: String = contentSource.reindexEndpointWithDateParams(dateParameters)
+    val headers = contentSource
+      .headers
+      .getOrElse(Map.empty)
+      .toList
+
     logger.info(s"Requesting reindex from url: ${reindexUrl}")
-    ws.url(reindexUrl).post("") flatMap { response =>
+    ws.url(reindexUrl).withHttpHeaders(headers: _*).post("").flatMap { response =>
       response.status match {
         case 200 | 201 =>
           val runningJob = RunningJob(contentSource.id, contentSource.environment, dateParameters)

--- a/public/components/contentSourceCreate.react.js
+++ b/public/components/contentSourceCreate.react.js
@@ -2,10 +2,9 @@ import React from 'react';
 import update from 'react-addons-update';
 import { Input, Button, ButtonToolbar, Alert, Col, Glyphicon, Row } from 'react-bootstrap';
 import ContentSourceService from '../services/contentSourceService';
+import {emptyHeader, headerListToHeaderMap, HeadersForm} from "./headersForm";
 
 export default class ContentSourceForm extends React.Component {
-    emptyHeader = { key: "", value: ""};
-
     constructor(props) {
         super(props);
         this.render = this.render.bind(this);
@@ -104,25 +103,6 @@ export default class ContentSourceForm extends React.Component {
         this.setState({supportsCancelReindex: e.target.checked});
     }
 
-    getHeadersOrDefault(id) {
-        return this.state.environments[id].headers ?? [this.emptyHeader]
-    }
-
-    handleHeaderChange(value, key, index, id) {
-        const newHeaders = [...this.getHeadersOrDefault(id)];
-        newHeaders[index] = { ...newHeaders[index], [key]: value };
-        this.handleEnvironmentsChange(id, "headers", newHeaders)
-    }
-
-    addHeader(id) {
-        const newHeaders = [...this.getHeadersOrDefault(id), this.emptyHeader];
-        this.handleEnvironmentsChange(id, "headers", newHeaders)
-    }
-
-    removeHeader(index, id) {
-        const newHeaders = this.getHeadersOrDefault(id).filter((_, localIndex) => localIndex !== index);
-        this.handleEnvironmentsChange(id, "headers", newHeaders)
-    }
 
     handleSubmit(e) {
         e.preventDefault();
@@ -144,7 +124,7 @@ export default class ContentSourceForm extends React.Component {
                         supportsToFromParams: supportsToFromParams,
                         supportsCancelReindex: supportsCancelReindex
                     },
-                    ...(obj.headers ? { headers: obj.headers } : {})
+                    ...(obj.headers ? headerListToHeaderMap(obj.headers) : {})
                 };
             }, this);
 
@@ -209,33 +189,12 @@ export default class ContentSourceForm extends React.Component {
                                                     </Input>
                                                 </Col>
                                             </Row>
-
                                             <Row>
                                                 <Col xs={12}>
-                                                    <Input label="Headers" labelClassName="col-xs-2" wrapperClassName="wrapper">
-                                                        <Col xs={10}>
-                                                            {(e.headers ?? [this.emptyHeader]).map(({ key, value }, index) =>
-                                                                <Row>
-                                                                    <Col xs={4} className="no-margin-bottom">
-                                                                        <input type="text" placeholder="Add a header key" onChange={(e) => this.handleHeaderChange(e.target.value, "key", index, id)} className="form-control" value={key}>
-                                                                        </input>
-                                                                    </Col>
-                                                                    <Col xs={4} className="no-margin-bottom">
-                                                                        <input type="text" placeholder="Add a header value" onChange={(e) => this.handleHeaderChange(e.target.value, "value", index, id)} className="form-control" value={value}>
-                                                                        </input>
-                                                                    </Col>
-                                                                    <Col xs={2}>
-                                                                        <Button className="remove-btn pull-right btn btn-link btn-sm" onClick={this.removeHeader.bind(this, index, id)}><Glyphicon glyph="glyphicon glyphicon-minus" /> Remove header</Button>
-                                                                    </Col>
-                                                                </Row>
-                                                            )}
-                                                            <Row>
-                                                                <Col  xs={12}>
-                                                                    <Button className="remove-btn pull-left btn btn-link btn-sm" onClick={this.addHeader.bind(this, id)}><Glyphicon glyph="glyphicon glyphicon-plus" /> Add another header</Button>
-                                                                </Col>
-                                                            </Row>
-                                                        </Col>
-                                                    </Input>
+                                                    <HeadersForm
+                                                        headers={e.headers}
+                                                        onChange={(headers) => this.handleEnvironmentsChange(id, "headers", headers)}
+                                                    />
                                                 </Col>
                                             </Row>
                                         </div>

--- a/public/components/contentSourceCreate.react.js
+++ b/public/components/contentSourceCreate.react.js
@@ -124,7 +124,7 @@ export default class ContentSourceForm extends React.Component {
                         supportsToFromParams: supportsToFromParams,
                         supportsCancelReindex: supportsCancelReindex
                     },
-                    ...(obj.headers ? headerListToHeaderMap(obj.headers) : {})
+                    ...(obj.headers ? { headers: headerListToHeaderMap(obj.headers) } : {})
                 };
             }, this);
 

--- a/public/components/contentSourceCreate.react.js
+++ b/public/components/contentSourceCreate.react.js
@@ -2,7 +2,7 @@ import React from 'react';
 import update from 'react-addons-update';
 import { Input, Button, ButtonToolbar, Alert, Col, Glyphicon, Row } from 'react-bootstrap';
 import ContentSourceService from '../services/contentSourceService';
-import {emptyHeader, headerListToHeaderMap, HeadersForm} from "./headersForm";
+import {headerListToHeaderMap, HeadersForm} from "./headersForm";
 
 export default class ContentSourceForm extends React.Component {
     constructor(props) {

--- a/public/components/contentSourceEdit.react.js
+++ b/public/components/contentSourceEdit.react.js
@@ -13,7 +13,7 @@ export default class ContentSourceEdit extends React.Component {
             description: this.props.contentSource.description,
             reindexEndpoint: this.props.contentSource.reindexEndpoint,
             authType: this.props.contentSource.authType,
-            headers: Object.entries(this.props.contentSource.headers).map(([key, value]) => ({ key, value })),
+            headers: Object.entries(this.props.contentSource.headers ?? {}).map(([key, value]) => ({ key, value })),
             supportsToFromParams: this.props.contentSource.contentSourceSettings.supportsToFromParams,
             supportsCancelReindex: this.props.contentSource.contentSourceSettings.supportsCancelReindex,
             alertStyle: 'success',

--- a/public/components/contentSourceEdit.react.js
+++ b/public/components/contentSourceEdit.react.js
@@ -13,7 +13,7 @@ export default class ContentSourceEdit extends React.Component {
             description: this.props.contentSource.description,
             reindexEndpoint: this.props.contentSource.reindexEndpoint,
             authType: this.props.contentSource.authType,
-            headers: this.props.contentSource.headers,
+            headers: Object.entries(this.props.contentSource.headers).map(([key, value]) => ({ key, value })),
             supportsToFromParams: this.props.contentSource.contentSourceSettings.supportsToFromParams,
             supportsCancelReindex: this.props.contentSource.contentSourceSettings.supportsCancelReindex,
             alertStyle: 'success',
@@ -67,7 +67,7 @@ export default class ContentSourceEdit extends React.Component {
                  description: description,
                  reindexEndpoint: reindexEndpoint,
                  authType: authType,
-                 ...(this.state.headers ? headerListToHeaderMap(this.state.headers) : {}),
+                 ...(this.state.headers ? { headers: headerListToHeaderMap(this.state.headers) } : {}),
                  contentSourceSettings: {
                      supportsToFromParams: supportsToFromParams,
                      supportsCancelReindex: supportsCancelReindex

--- a/public/components/contentSourceEdit.react.js
+++ b/public/components/contentSourceEdit.react.js
@@ -2,6 +2,7 @@ import React from 'react';
 import * as R from 'ramda';
 import { Button, ButtonToolbar, Input, Alert, Col } from 'react-bootstrap';
 import ContentSourceService from '../services/contentSourceService';
+import {headerListToHeaderMap, HeadersForm} from "./headersForm";
 
 export default class ContentSourceEdit extends React.Component {
 
@@ -12,6 +13,7 @@ export default class ContentSourceEdit extends React.Component {
             description: this.props.contentSource.description,
             reindexEndpoint: this.props.contentSource.reindexEndpoint,
             authType: this.props.contentSource.authType,
+            headers: this.props.contentSource.headers,
             supportsToFromParams: this.props.contentSource.contentSourceSettings.supportsToFromParams,
             supportsCancelReindex: this.props.contentSource.contentSourceSettings.supportsCancelReindex,
             alertStyle: 'success',
@@ -65,6 +67,7 @@ export default class ContentSourceEdit extends React.Component {
                  description: description,
                  reindexEndpoint: reindexEndpoint,
                  authType: authType,
+                 ...(this.state.headers ? headerListToHeaderMap(this.state.headers) : {}),
                  contentSourceSettings: {
                      supportsToFromParams: supportsToFromParams,
                      supportsCancelReindex: supportsCancelReindex
@@ -96,7 +99,10 @@ export default class ContentSourceEdit extends React.Component {
                         <option value="api-key">Api key</option>
                         <option value="vpc-peered">VPC peered</option>
                     </Input>
-
+                    <HeadersForm
+                        headers={this.state.headers}
+                        onChange={(headers) => this.setState({ "headers": headers })}
+                    />
                     <Input label="Settings" labelClassName="col-xs-2" wrapperClassName="wrapper">
                         <Col xs={4}>
                             <Input type="checkbox" defaultChecked={this.state.supportsToFromParams} onChange={this.handleSupportsToFromParams.bind(this)} label="Supports to/from reindex parameters" />
@@ -105,7 +111,6 @@ export default class ContentSourceEdit extends React.Component {
                             <Input type="checkbox" defaultChecked={this.state.supportsCancelReindex} onChange={this.handleSupportsCancelReindex.bind(this)} label="Supports cancelling of a reindex" />
                         </Col>
                     </Input>
-
                     <ButtonToolbar>
                         <Button bsStyle="success" className="pull-right" type="submit">Submit</Button>
                         <Button bsStyle="danger" className="pull-right" type="button" onClick={this.exitEditMode}>Cancel</Button>

--- a/public/components/headersForm.js
+++ b/public/components/headersForm.js
@@ -1,0 +1,74 @@
+import {Button, Col, Glyphicon, Input, Row} from "react-bootstrap";
+import React from "react";
+
+export const emptyHeader = { key: "", value: ""};
+
+export const headerListToHeaderMap = (headerList) => headerList.reduce((acc, { key, value }) => ({
+    ...acc,
+    [key]: value
+}), {})
+
+/**
+ * @param props {{
+ *   headers: Array<{key: string, value: string}>,
+ *   onChange: (headers: Array<{key: string, value: string}>) => void
+ * }}
+ */
+export class HeadersForm extends React.Component {
+    getHeadersOrDefault = (id) => {
+        return this.props.headers ?? [emptyHeader]
+    }
+
+    handleHeaderChange = (value, key, index) => {
+        const newHeaders = [...this.getHeadersOrDefault()];
+        newHeaders[index] = { ...newHeaders[index], [key]: value };
+        this.props.onChange(newHeaders)
+    }
+
+    addHeader = () => {
+        const newHeaders = [...this.getHeadersOrDefault(), emptyHeader];
+        this.props.onChange(newHeaders)
+    }
+
+    removeHeader = (index) => {
+        const newHeaders = this.getHeadersOrDefault().filter((_, localIndex) => localIndex !== index);
+        this.props.onChange(newHeaders)
+    }
+
+    render = () => {
+        const {headers} = this.props;
+        return <Input label="Headers" labelClassName="col-xs-2" wrapperClassName="wrapper">
+            <Col xs={10}>
+                {(headers ?? [emptyHeader]).map(({key, value}, index) =>
+                    <Row key={`${key}-${value}-${index}`}>
+                        <Col xs={4} className="no-margin-bottom">
+                            <input type="text" placeholder="Add a header key"
+                                   onChange={(e) => this.handleHeaderChange(e.target.value, "key", index)}
+                                   className="form-control" value={key}>
+                            </input>
+                        </Col>
+                        <Col xs={4} className="no-margin-bottom">
+                            <input type="text" placeholder="Add a header value"
+                                   onChange={(e) => this.handleHeaderChange(e.target.value, "value", index)}
+                                   className="form-control" value={value}>
+                            </input>
+                        </Col>
+                        <Col xs={2}>
+                            <Button className="remove-btn pull-right btn btn-link btn-sm"
+                                    onClick={() => this.removeHeader(index)}><Glyphicon
+                                glyph="glyphicon glyphicon-minus"/> Remove</Button>
+                        </Col>
+                    </Row>
+                )}
+                <Row>
+                    <Col xs={12}>
+                        <Button className="remove-btn pull-left btn btn-link btn-sm"
+                                onClick={this.addHeader}><Glyphicon
+                            glyph="glyphicon glyphicon-plus"/> Add
+                            another header</Button>
+                    </Col>
+                </Row>
+            </Col>
+        </Input>
+    }
+}

--- a/public/components/headersForm.js
+++ b/public/components/headersForm.js
@@ -15,7 +15,7 @@ export const headerListToHeaderMap = (headerList) => headerList.reduce((acc, { k
  * }}
  */
 export class HeadersForm extends React.Component {
-    getHeadersOrDefault = (id) => {
+    getHeadersOrDefault = () => {
         return this.props.headers ?? [emptyHeader]
     }
 
@@ -37,10 +37,11 @@ export class HeadersForm extends React.Component {
 
     render = () => {
         const {headers} = this.props;
+
         return <Input label="Headers" labelClassName="col-xs-2" wrapperClassName="wrapper">
             <Col xs={10}>
                 {(headers ?? [emptyHeader]).map(({key, value}, index) =>
-                    <Row key={`${key}-${value}-${index}`}>
+                    <Row key={index}>
                         <Col xs={4} className="no-margin-bottom">
                             <input type="text" placeholder="Add a header key"
                                    onChange={(e) => this.handleHeaderChange(e.target.value, "key", index)}

--- a/public/components/headersForm.js
+++ b/public/components/headersForm.js
@@ -1,9 +1,9 @@
 import {Button, Col, Glyphicon, Input, Row} from "react-bootstrap";
 import React from "react";
 
-export const emptyHeader = { key: "", value: ""};
+const emptyHeader = {key: "", value: ""};
 
-export const headerListToHeaderMap = (headerList) => headerList.reduce((acc, { key, value }) => ({
+export const headerListToHeaderMap = (headerList) => headerList.reduce((acc, {key, value}) => ({
     ...acc,
     [key]: value
 }), {})
@@ -16,12 +16,12 @@ export const headerListToHeaderMap = (headerList) => headerList.reduce((acc, { k
  */
 export class HeadersForm extends React.Component {
     getHeadersOrDefault = () => {
-        return this.props.headers ?? [emptyHeader]
+        return this.props.headers ?? []
     }
 
     handleHeaderChange = (value, key, index) => {
         const newHeaders = [...this.getHeadersOrDefault()];
-        newHeaders[index] = { ...newHeaders[index], [key]: value };
+        newHeaders[index] = {...newHeaders[index], [key]: value};
         this.props.onChange(newHeaders)
     }
 
@@ -35,41 +35,37 @@ export class HeadersForm extends React.Component {
         this.props.onChange(newHeaders)
     }
 
-    render = () => {
-        const {headers} = this.props;
-
-        return <Input label="Headers" labelClassName="col-xs-2" wrapperClassName="wrapper">
-            <Col xs={10}>
-                {(headers ?? [emptyHeader]).map(({key, value}, index) =>
-                    <Row key={index}>
-                        <Col xs={4} className="no-margin-bottom">
-                            <input type="text" placeholder="Add a header key"
-                                   onChange={(e) => this.handleHeaderChange(e.target.value, "key", index)}
-                                   className="form-control" value={key}>
-                            </input>
-                        </Col>
-                        <Col xs={4} className="no-margin-bottom">
-                            <input type="text" placeholder="Add a header value"
-                                   onChange={(e) => this.handleHeaderChange(e.target.value, "value", index)}
-                                   className="form-control" value={value}>
-                            </input>
-                        </Col>
-                        <Col xs={2}>
-                            <Button className="remove-btn pull-right btn btn-link btn-sm"
-                                    onClick={() => this.removeHeader(index)}><Glyphicon
-                                glyph="glyphicon glyphicon-minus"/> Remove</Button>
-                        </Col>
-                    </Row>
-                )}
-                <Row>
-                    <Col xs={12}>
-                        <Button className="remove-btn pull-left btn btn-link btn-sm"
-                                onClick={this.addHeader}><Glyphicon
-                            glyph="glyphicon glyphicon-plus"/> Add
-                            another header</Button>
+    render = () => <Input label="Headers" labelClassName="col-xs-2" wrapperClassName="wrapper">
+        <Col xs={10}>
+            {this.getHeadersOrDefault().map(({key, value}, index) =>
+                <Row key={index}>
+                    <Col xs={4} className="no-margin-bottom">
+                        <input type="text" placeholder="Add a header key"
+                               onChange={(e) => this.handleHeaderChange(e.target.value, "key", index)}
+                               className="form-control" value={key}>
+                        </input>
+                    </Col>
+                    <Col xs={4} className="no-margin-bottom">
+                        <input type="text" placeholder="Add a header value"
+                               onChange={(e) => this.handleHeaderChange(e.target.value, "value", index)}
+                               className="form-control" value={value}>
+                        </input>
+                    </Col>
+                    <Col xs={2}>
+                        <Button className="remove-btn pull-right btn btn-link btn-sm"
+                                onClick={() => this.removeHeader(index)}><Glyphicon
+                            glyph="glyphicon glyphicon-minus"/> Remove</Button>
                     </Col>
                 </Row>
-            </Col>
-        </Input>
-    }
+            )}
+            <Row>
+                <Col xs={12}>
+                    <Button className="remove-btn pull-left btn btn-link btn-sm"
+                            onClick={this.addHeader}><Glyphicon
+                        glyph="glyphicon glyphicon-plus"/> Add
+                        another header</Button>
+                </Col>
+            </Row>
+        </Col>
+    </Input>
 }

--- a/test/com/gu/floodgate/contentsource/ContentSourceReindexUrlTest.scala
+++ b/test/com/gu/floodgate/contentsource/ContentSourceReindexUrlTest.scala
@@ -15,7 +15,8 @@ class ContentSourceReindexUrlTest extends AnyFlatSpec with Matchers {
       reindexEndpoint = "http://myurl.com/reindex?api-key=my-key",
       environment = "code-live",
       authType = "api-key",
-      contentSourceSettings = ContentSourceSettings(true, true)
+      contentSourceSettings = ContentSourceSettings(true, true),
+      headers = None
     )
 
   val contentSourceWithVpcPeerAuth = ContentSource(
@@ -25,7 +26,8 @@ class ContentSourceReindexUrlTest extends AnyFlatSpec with Matchers {
     reindexEndpoint = "http://myurl.com/reindex",
     environment = "code-live",
     authType = "vpc-peered",
-    contentSourceSettings = ContentSourceSettings(true, true)
+    contentSourceSettings = ContentSourceSettings(true, true),
+    headers = None
   )
 
   it should "return the correct url to initiate a reindex when using api-key auth" in {

--- a/test/com/gu/floodgate/contentsource/ContentSourceSpec.scala
+++ b/test/com/gu/floodgate/contentsource/ContentSourceSpec.scala
@@ -10,7 +10,8 @@ class ContentSourceSpec extends AnyFlatSpec with Matchers  {
     reindexEndpoint = "http://myurl.com/reindex?api-key=my-key",
     environment = "code-live",
     authType = "api-key",
-    contentSourceSettings = ContentSourceSettings(true, true)
+    contentSourceSettings = ContentSourceSettings(true, true),
+    headers = None
   )
 
   val contentSourceWithoutIdAndEnvironment = ContentWithoutIdAndEnvironment(
@@ -18,7 +19,8 @@ class ContentSourceSpec extends AnyFlatSpec with Matchers  {
     description = "description of my reindexer",
     reindexEndpoint = "http://myurl.com/reindex?api-key=my-key",
     authType = "api-key",
-    contentSourceSettings = ContentSourceSettings(true, true)
+    contentSourceSettings = ContentSourceSettings(true, true),
+    headers = None
   )
 
   it should "add a UUID when a content source is created from a ContentSourceWithoutId" in {


### PR DESCRIPTION
## What does this change?

Permit adding, removing and editing headers to floodgate content sources, and send those headers when making requests.

![floodgate](https://github.com/user-attachments/assets/12a6527e-d86f-46dc-b7cf-72628170a8ce)

The latter part is currently untested, although simple to add ([3f13bd1](https://github.com/guardian/floodgate/pull/146/commits/3f13bd1386f7e56cf9d3f725848d137bf30f6184)) — if there's appetite perhaps we could use [play-mockws](https://github.com/leanovate/play-mockws) to add a test.

## How to test

- Add a new content source. You should be able to add arbitrary headers. Or not.
- Inspect the content source after refreshing the page. The headers should be present in the UI.
- Edit the content source, adding and removing headers. This should also work as expected.


