### PR TITLE
Do not duplicate content sources on edit

### DIFF
--- a/app/com/gu/floodgate/contentsource/ContentSource.scala
+++ b/app/com/gu/floodgate/contentsource/ContentSource.scala
@@ -107,7 +107,6 @@ object ContentSource {
   }
 
   def apply(id: String, environment: String, contentSource: ContentWithoutIdAndEnvironment): ContentSource = {
-    val id = UUID.randomUUID().toString
     ContentSource(
       id,
       contentSource.appName,

--- a/test/com/gu/floodgate/contentsource/ContentSourceSpec.scala
+++ b/test/com/gu/floodgate/contentsource/ContentSourceSpec.scala
@@ -1,0 +1,38 @@
+package com.gu.floodgate.contentsource
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ContentSourceSpec extends AnyFlatSpec with Matchers  {
+  val contentSourceWithoutId = ContentSourceWithoutId(
+    appName = "my reindexer",
+    description = "description of my reindexer",
+    reindexEndpoint = "http://myurl.com/reindex?api-key=my-key",
+    environment = "code-live",
+    authType = "api-key",
+    contentSourceSettings = ContentSourceSettings(true, true)
+  )
+
+  val contentSourceWithoutIdAndEnvironment = ContentWithoutIdAndEnvironment(
+    appName = "my reindexer",
+    description = "description of my reindexer",
+    reindexEndpoint = "http://myurl.com/reindex?api-key=my-key",
+    authType = "api-key",
+    contentSourceSettings = ContentSourceSettings(true, true)
+  )
+
+  it should "add a UUID when a content source is created from a ContentSourceWithoutId" in {
+    val contentSource = ContentSource(contentSourceWithoutId)
+    contentSource.id.length shouldBe 36
+  }
+
+  it should "preserve the current ID when a content source is created from a ContentSourceWithoutId and an id is supplied" in {
+    val contentSource = ContentSource("explicit-id", contentSourceWithoutId)
+    contentSource.id shouldBe "explicit-id"
+  }
+
+  it should "preserve the ID when a content source is created from a ContentWithoutIdAndEnvironment but an id is supplied" in {
+    val contentSource = ContentSource("explicit-id", "code-live", contentSourceWithoutIdAndEnvironment)
+    contentSource.id shouldBe "explicit-id"
+  }
+}


### PR DESCRIPTION
## What does this change?

Preserves the ID property passed to `apply` when `ContentSource`s are created from `ContentWithoutEnvironmentOrId`s.

This looks like an oversight in [this commit](https://github.com/guardian/floodgate/commit/ca44162b76bc2a6283f2f19f4174284ada61743b), preserving [id generation in the original apply method](https://github.com/guardian/floodgate/blame/42a954abc00095c4cf904181245d09bdd130c764/app/com/gu/floodgate/contentsource/ContentSource.scala) and missing the shadowed variable. 

The result is a new content source every time you make an edit. If this PR is correct, it seems like it's either very rare that we use 'edit' in this way, or it ... has never happened 😅 

<img width="948" alt="Screenshot 2024-11-19 at 11 34 26" src="https://github.com/user-attachments/assets/8d95e032-74cf-4558-87bc-a158239ae3be">

## How to test

- The automated tests should pass. They're arguably overkill but it felt strange shipping an important fix without tests.
- Deploy to ~CODE~ PROD, and edit a new content source (perhaps the description? Something that doesn't break reindexing ~CODE~ PROD 😀 ). On refresh, you should not see a new, identical content source created as a result of the edit. 