### PR TITLE
Fix annoying secondary rate limit issue in build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
               - target/content-api-floodgate_1.0_all.deb
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always() #runs even if there is a test failure
         with:
           files: junit-tests/*.xml


### PR DESCRIPTION
## What does this change?

Bumps the version of the action which posts test results, to avoid builds failing on "secondary rate limit"

## How to test

If it builds, it's working 😁 

## How can we measure success?

Working builds

## Have we considered potential risks?

n/a
