### PR TITLE
Upgrade OS via new AMI

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -20,6 +20,6 @@ deployments:
       amiParameter: AMIContentapifloodgate
       amiEncrypted: true
       amiTags:
-        Recipe: ubuntu-focal-capi-arm-jdk11
+        Recipe: ubuntu-jammy-capi-arm-jdk11
         AmigoStage: PROD
         BuiltBy: amigo


### PR DESCRIPTION
## What does this change?

Focal is no longer supported. Move to Jammy.

## How to test

Deploy it to PROD. If that fails, revert and redeploy. It'll likely be a hard fail if it doesn't work, so we're not expecting to have to figure out subtleties.

## How can we measure success?

If it deploys, we can run a couple of trial tasks with it, but TBH if it runs it's likely just fine.

## Have we considered potential risks?

Risks are minimal, we're expecting a pretty binary outcome, which we can revert if things do act up.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A - there are no UI changes here
