### PR TITLE
feat(cdk): Switch to more conventional SSM Parameter names for the VPC

### DIFF
--- a/cdk/lib/__snapshots__/floodgate.test.ts.snap
+++ b/cdk/lib/__snapshots__/floodgate.test.ts.snap
@@ -5,8 +5,10 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuParameter",
-      "GuParameter",
       "GuPolicy",
+      "GuVpcParameter",
+      "GuSubnetListParameter",
+      "GuSubnetListParameter",
       "GuEc2App",
       "GuCertificate",
       "GuInstanceRole",
@@ -64,14 +66,20 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
       "Default": "/account/services/capi.gutools/TEST/hostedzoneid",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "SsmParameterValueaccountvpcTESTgenericidC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/account/vpc/TEST-generic/id",
-      "Type": "AWS::SSM::Parameter::Value<String>",
+    "VpcId": {
+      "Default": "/account/vpc/vpc-content-platforms-TEST/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
-    "subnets": {
-      "Default": "/account/vpc/TEST-generic/subnets",
-      "Description": "Subnets to deploy into",
-      "Type": "AWS::SSM::Parameter::Value<List<String>>",
+    "contentapifloodgatePrivateSubnets": {
+      "Default": "/account/vpc/vpc-content-platforms-TEST/subnets/public",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "contentapifloodgatePublicSubnets": {
+      "Default": "/account/vpc/vpc-content-platforms-TEST/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
   },
   "Resources": {
@@ -142,7 +150,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
           },
         ],
         "VPCZoneIdentifier": {
-          "Ref": "subnets",
+          "Ref": "contentapifloodgatePrivateSubnets",
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
@@ -397,7 +405,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
           },
         ],
         "VpcId": {
-          "Ref": "SsmParameterValueaccountvpcTESTgenericidC96584B6F00A464EAD1953AFF4B05118Parameter",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -625,7 +633,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
           },
         ],
         "VpcId": {
-          "Ref": "SsmParameterValueaccountvpcTESTgenericidC96584B6F00A464EAD1953AFF4B05118Parameter",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -797,7 +805,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
           },
         ],
         "Subnets": {
-          "Ref": "subnets",
+          "Ref": "contentapifloodgatePublicSubnets",
         },
         "Tags": [
           {
@@ -860,7 +868,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
           },
         ],
         "VpcId": {
-          "Ref": "SsmParameterValueaccountvpcTESTgenericidC96584B6F00A464EAD1953AFF4B05118Parameter",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
@@ -1100,7 +1108,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
         "TargetType": "instance",
         "UnhealthyThresholdCount": 2,
         "VpcId": {
-          "Ref": "SsmParameterValueaccountvpcTESTgenericidC96584B6F00A464EAD1953AFF4B05118Parameter",
+          "Ref": "VpcId",
         },
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",

--- a/cdk/lib/floodgate.ts
+++ b/cdk/lib/floodgate.ts
@@ -4,9 +4,9 @@ import type {App} from "aws-cdk-lib";
 import {aws_ssm, Stack} from "aws-cdk-lib";
 import {GuEc2App} from "@guardian/cdk";
 import {AccessScope} from "@guardian/cdk/lib/constants";
-import {InstanceClass, InstanceSize, InstanceType, Peer, Port, UserData, Vpc} from "aws-cdk-lib/aws-ec2";
+import {InstanceClass, InstanceSize, InstanceType, Peer, Port, UserData} from "aws-cdk-lib/aws-ec2";
 import fs from "fs";
-import {GuSecurityGroup, GuVpc} from "@guardian/cdk/lib/constructs/ec2";
+import {GuSecurityGroup} from "@guardian/cdk/lib/constructs/ec2";
 import {GuPolicy} from "@guardian/cdk/lib/constructs/iam";
 import {Effect, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Datastore} from "./datastore";
@@ -15,19 +15,7 @@ export class Floodgate extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {
     super(scope, id, props);
 
-    const vpcId = aws_ssm.StringParameter.valueForStringParameter(this, this.getVpcIdPath());
-    const vpc = Vpc.fromVpcAttributes(this, "vpc", {
-      vpcId: vpcId,
-      availabilityZones: ["eu-west-1a","eu-west-1b" ,"eu-west-1c"]
-    });
-
-    const subnetsList = new GuParameter(this, "subnets", {
-      description: "Subnets to deploy into",
-      default: this.getDeploymentSubnetsPath(),
-      fromSSM: true,
-      type: "List<String>"
-    });
-    const deploymentSubnets = GuVpc.subnets(this, subnetsList.valueAsList);
+    const app = "content-api-floodgate";
 
     const datastore = new Datastore(this, "Datastore");
 
@@ -50,12 +38,12 @@ export class Floodgate extends GuStack {
 
     const userData = UserData.custom(userDataProcessed);
 
-    const app = new GuEc2App(this, {
+    const ec2App = new GuEc2App(this, {
       instanceMetricGranularity: "1Minute",
       access: {
         scope: AccessScope.PUBLIC,
       },
-      app: "content-api-floodgate",
+      app,
       applicationLogging: {
         enabled: true,
         systemdUnitName: "content-api-floodgate"
@@ -117,18 +105,15 @@ export class Floodgate extends GuStack {
         },
         unhealthyInstancesAlarm: true,
       },
-      privateSubnets: deploymentSubnets,
-      publicSubnets: deploymentSubnets,
       scaling: {
         minimumInstances: 1,
         maximumInstances: 2,
       },
       userData: userData,
-      vpc
     });
 
-    app.autoScalingGroup.connections.addSecurityGroup(new GuSecurityGroup(this, "InstanceOutboundSG", {
-      app: "content-api-floodgate",
+    ec2App.autoScalingGroup.connections.addSecurityGroup(new GuSecurityGroup(this, "InstanceOutboundSG", {
+      app,
       allowAllOutbound: false,
       allowAllIpv6Outbound: false,
       egresses: [
@@ -138,20 +123,29 @@ export class Floodgate extends GuStack {
           description: "Outgoing to port 8080 on internal infrastructure"
         }
       ],
-      vpc,
+      vpc: ec2App.vpc,
     }))
-  }
 
-  getAccountPath(elementName: string) {
-    const basePath = "/account/vpc";
-    return `${basePath}/${this.stage}-generic/${elementName}`;
-  }
+    /*
+    These parameters are added to the stack via GuEc2App.
+    By default, the VPC name used is "primary".
+    Customise it to ensure the correct VPC is used for this app.
+     */
+    const maybeVpcId = this.parameters["VpcId"];
+    const maybeVpcPublicSubnets = this.parameters[`${app}PublicSubnets`];
+    const maybeVpcPrivateSubnets = this.parameters[`${app}PrivateSubnets`];
 
-  getVpcIdPath() {
-    return this.getAccountPath("id");
-  }
+    if (!maybeVpcId || !maybeVpcPublicSubnets || !maybeVpcPrivateSubnets) {
+      throw new Error("VPC parameters not found. Unable to synth valid CloudFormation template.");
+    }
 
-  getDeploymentSubnetsPath() {
-    return this.getAccountPath("subnets")
+    const vpcName = `vpc-content-platforms-${this.stage}`;
+
+    maybeVpcId.default = `/account/vpc/${vpcName}/id`;
+    maybeVpcPublicSubnets.default = `/account/vpc/${vpcName}/subnets/public`;
+
+    // We do not yet have any private subnets in this VPC, so use the public subnets for now.
+    // TODO: Update this when private subnets are available.
+    maybeVpcPrivateSubnets.default = `/account/vpc/${vpcName}/subnets/public`;
   }
 }


### PR DESCRIPTION
Requires:
- https://github.com/guardian/content-api/pull/3133
- https://github.com/guardian/floodgate/pull/168
- https://github.com/guardian/floodgate/pull/169

## What does this change?
The SSM Parameter `/account/vpc/<STAGE>-generic/id` isn't intention revealing and doesn't follow the departmental convention. Update it to use the SSM Parameter `/account/vpc/vpc-content-platforms-<STAGE>/id`. The SSM Parameters resolve to the same VPC.

> [!NOTE]
> This VPC doesn't yet have any private subnets, so we're patching the private subnet parameter to point to the public subnets.

This change is the same as https://github.com/guardian/apple-news/pull/463 but for this repository.

## How to test
TBD.