### PR TITLE
fix: Stop producing CFN for CODE

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,7 +56,6 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           contentDirectories: |
             cloudformation:
-              - cdk/cdk.out/Floodgate-CODE.template.json
               - cdk/cdk.out/Floodgate-PROD.template.json
             content-api-floodgate:
               - target/content-api-floodgate_1.0_all.deb

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -4,4 +4,4 @@ import { Floodgate } from "../lib/floodgate";
 
 const app = new App();
 new Floodgate(app, "Floodgate-PROD", { stack: "content-api-floodgate", stage: "PROD" });
-new Floodgate(app, "Floodgate-CODE", { stack: "content-api-floodgate", stage: "CODE" });
+

--- a/cdk/lib/floodgate.ts
+++ b/cdk/lib/floodgate.ts
@@ -11,8 +11,6 @@ import {GuPolicy} from "@guardian/cdk/lib/constructs/iam";
 import {Effect, PolicyStatement} from "aws-cdk-lib/aws-iam";
 import {Datastore} from "./datastore";
 
-const useArm = true;
-
 export class Floodgate extends GuStack {
   constructor(scope: App, id: string, props: GuStackProps) {
     super(scope, id, props);
@@ -106,7 +104,7 @@ export class Floodgate extends GuStack {
         domainName: this.stage==="CODE" ? "floodgate.capi.code.dev-gutools.co.uk" : "floodgate.capi.gutools.co.uk",
         hostedZoneId: dnsZone,
       },
-      instanceType: useArm ? InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL) : InstanceType.of(InstanceClass.T3, InstanceSize.SMALL),
+      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
       monitoringConfiguration: {
         snsTopicName: `floogate-monitoring-${this.stage}`,
         http5xxAlarm: {

--- a/cdk/lib/floodgate.ts
+++ b/cdk/lib/floodgate.ts
@@ -101,7 +101,8 @@ export class Floodgate extends GuStack {
       },
       applicationPort: 9000,
       certificateProps: {
-        domainName: this.stage==="CODE" ? "floodgate.capi.code.dev-gutools.co.uk" : "floodgate.capi.gutools.co.uk",
+        // TODO push this to props if/when we add a CODE stage
+        domainName: "floodgate.capi.gutools.co.uk",
         hostedZoneId: dnsZone,
       },
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,3 +1,6 @@
+allowedStages:
+  - PROD
+
 stacks:
   - content-api-floodgate
 
@@ -15,7 +18,6 @@ deployments:
     app: content-api-floodgate
     parameters:
       templateStagePaths:
-        CODE: Floodgate-CODE.template.json
         PROD: Floodgate-PROD.template.json
       amiParameter: AMIContentapifloodgate
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?
Stop producing a CFN template for CODE as we're not running floodgate in CODE.

<details><summary>Screenshot from AWS console showing floodgate stacks</summary>
<p>

<img width="715" height="351" alt="image" src="https://github.com/user-attachments/assets/7c15dd1d-8e45-4785-892b-29b58da4e837" />

</p>
</details> 
