### PR TITLE
ci: Update triggers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,17 @@
 name: Build and upload
 
-on: [push]
+# Produce a build when...
+on:
+  # ...we raise (or commit to) a pull request
+  pull_request:
+
+  # ...or we push to main, e.g. merge a pull request
+  push:
+    branches:
+      - main
+
+  # ...or we manually invoke the build
+  workflow_dispatch:
 
 jobs:
   floodgate:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,10 @@ jobs:
 
       - uses: guardian/actions-riff-raff@v4
         with:
+          # There's only one stage, PROD.
+          # Ideally, we'd only deploy to PROD from main, so don't add the "deploy to <STAGE>" comment.
+          commentingEnabled: false
+
           configPath: riff-raff.yaml
           projectName: Content Platforms::floodgate
           buildNumberOffset: 397


### PR DESCRIPTION
## What does this change?
Update the triggers for CI as building per push is a bit excessive and isn't necessary. Additionally, following https://github.com/guardian/floodgate/pull/166, configure `guardian/actions-riff-raff` to not comment on PRs as we should avoid deploying feature branches to PROD.

<details><summary>Additional benefits</summary>
<p>

The commenting behaviour of https://github.com/guardian/actions-riff-raff inspects the calling payload and tries to associate it with a pull request.

If the build triggered on push completes before the PR is opened[^1], a comment is not produced. Any subsequent commits to a PR will yield a comment. This is a little confusing.

This should fix that. By triggering the workflow on `pull_request` we know that `guardian/actions-riff-raff` will be able to locate a PR to comment on.

Alas, this doesn't really matter following https://github.com/guardian/floodgate/pull/166.

</p>
</details> 

---

Relates to https://github.com/guardian/platform/pull/1684 and https://github.com/guardian/platform/pull/1683.

[^1]: For example https://github.com/guardian/floodgate/pull/166.