### PR TITLE
fix: Remove now unused `WazuhSecurityGroup`

### DIFF
--- a/cdk/lib/__snapshots__/floodgate.test.ts.snap
+++ b/cdk/lib/__snapshots__/floodgate.test.ts.snap
@@ -1224,40 +1224,6 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "WazuhSecurityGroup": {
-      "Properties": {
-        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/floodgate",
-          },
-          {
-            "Key": "Stack",
-            "Value": "content-api-floodgate",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VpcId": {
-          "Ref": "SsmParameterValueaccountvpcTESTgenericidC96584B6F00A464EAD1953AFF4B05118Parameter",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
     "contentapifloodgateTESTcontentapifloodgateE40DDE74": {
       "DependsOn": [
         "InstanceRoleContentapifloodgate4A6AA3CB",

--- a/cdk/lib/floodgate.ts
+++ b/cdk/lib/floodgate.ts
@@ -4,7 +4,7 @@ import type {App} from "aws-cdk-lib";
 import {aws_ssm, Stack} from "aws-cdk-lib";
 import {GuEc2App} from "@guardian/cdk";
 import {AccessScope} from "@guardian/cdk/lib/constants";
-import {InstanceClass, InstanceSize, InstanceType, Peer, Port, SecurityGroup, UserData, Vpc} from "aws-cdk-lib/aws-ec2";
+import {InstanceClass, InstanceSize, InstanceType, Peer, Port, UserData, Vpc} from "aws-cdk-lib/aws-ec2";
 import fs from "fs";
 import {GuSecurityGroup, GuVpc} from "@guardian/cdk/lib/constructs/ec2";
 import {GuPolicy} from "@guardian/cdk/lib/constructs/iam";
@@ -140,21 +140,6 @@ export class Floodgate extends GuStack {
       ],
       vpc,
     }))
-
-
-    // A temporary security group with a fixed logical ID, replicating the one removed from GuCDK v61.5.0.
-    // See https://github.com/guardian/cdk/releases/tag/v61.5.0.
-    const tempSecurityGroup = new SecurityGroup(this, "WazuhSecurityGroup", {
-      vpc,
-      // Must keep the same description, else CloudFormation will try to replace the security group
-      // See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-securitygroup.html#cfn-ec2-securitygroup-groupdescription.
-      description: "Allow outbound traffic from wazuh agent to manager",
-    });
-    this.overrideLogicalId(tempSecurityGroup, {
-      logicalId: "WazuhSecurityGroup",
-      reason:
-       "Part one of updating to GuCDK 61.5.0+ whilst using Riff-Raff's ASG deployment type",
-    });
   }
 
   getAccountPath(elementName: string) {


### PR DESCRIPTION
## What does this change?
Follows #168 to remove the temporary `WazuhSecurityGroup`. See also https://github.com/guardian/cdk/releases/tag/v61.5.0.