### PR TITLE
Relocate instance into private subnets

### DIFF
--- a/cdk/lib/__snapshots__/floodgate.test.ts.snap
+++ b/cdk/lib/__snapshots__/floodgate.test.ts.snap
@@ -72,7 +72,7 @@ exports[`The Floodgate stack matches the snapshot 1`] = `
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
     "contentapifloodgatePrivateSubnets": {
-      "Default": "/account/vpc/vpc-content-platforms-TEST/subnets/public",
+      "Default": "/account/vpc/vpc-content-platforms-TEST/subnets/private",
       "Description": "A list of private subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },

--- a/cdk/lib/floodgate.ts
+++ b/cdk/lib/floodgate.ts
@@ -144,8 +144,6 @@ export class Floodgate extends GuStack {
     maybeVpcId.default = `/account/vpc/${vpcName}/id`;
     maybeVpcPublicSubnets.default = `/account/vpc/${vpcName}/subnets/public`;
 
-    // We do not yet have any private subnets in this VPC, so use the public subnets for now.
-    // TODO: Update this when private subnets are available.
-    maybeVpcPrivateSubnets.default = `/account/vpc/${vpcName}/subnets/public`;
+    maybeVpcPrivateSubnets.default = `/account/vpc/${vpcName}/subnets/private`;
   }
 }

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -21,7 +21,7 @@ deployments:
         PROD: Floodgate-PROD.template.json
       templateStageParameters:
         PROD:
-          contentapifloodgatePrivateSubnets: /account/vpc/vpc-content-platforms-PROD/subnets/private
+          contentapifloodgatePrivateSubnets: /account/vpc/vpc-content-platforms-PROD/subnets/public
       amiParameter: AMIContentapifloodgate
       amiEncrypted: true
       amiTags:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -19,6 +19,9 @@ deployments:
     parameters:
       templateStagePaths:
         PROD: Floodgate-PROD.template.json
+      templateStageParameters:
+        PROD:
+          contentapifloodgatePrivateSubnets: /account/vpc/vpc-content-platforms-PROD/subnets/private
       amiParameter: AMIContentapifloodgate
       amiEncrypted: true
       amiTags:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -21,7 +21,7 @@ deployments:
         PROD: Floodgate-PROD.template.json
       templateStageParameters:
         PROD:
-          contentapifloodgatePrivateSubnets: /account/vpc/vpc-content-platforms-PROD/subnets/public
+          contentapifloodgatePrivateSubnets: /account/vpc/vpc-content-platforms-PROD/subnets/private
       amiParameter: AMIContentapifloodgate
       amiEncrypted: true
       amiTags:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We've created private subnets in our `content-platforms-{STAGE}` stacks, so now we can move this service instance over to there and surrender our public IP addresses, which we don't need anyway 🎉 

## How to test

We only have a PROD instance of floodgate, so we'd have to test there. However this does follow almost exactly the same pattern as https://github.com/guardian/apple-news/pull/466, which we know worked successfully.

Also, floodgate is only of internal interest, so if it doesn't quite go as expected for some reason, it's not going to break the world.

## How can we measure success?

Deploy and kick off a test reindex. If it works, success!

## Have we considered potential risks?

Risks are minimal. We can redeploy the last good build very quickly, or we can revert and take stock if needs be.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A - there are no UI changes here
